### PR TITLE
fix wrong dimension ordering into cv::Size.

### DIFF
--- a/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
+++ b/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
@@ -1066,7 +1066,7 @@ void Impl::preparePrimsForTensor(const GVA::Tensor &tensor, GVA::Rect<double> re
         std::vector<float> mask = tensor.data<float>();
         std::vector<guint> dims = tensor.dims();
         assert(dims.size() == 2);
-        const cv::Size &mask_size{int(dims[0]), int(dims[1])};
+        const cv::Size &mask_size{int(dims[1]), int(dims[0])};
         cv::Rect2f box(rect.x, rect.y, rect.w, rect.h);
         Color color = indexToColor(color_index);
 
@@ -1096,7 +1096,7 @@ void Impl::preparePrimsForTensor(const GVA::Tensor &tensor, GVA::Rect<double> re
         assert(tensor.precision() == GVA::Tensor::Precision::I64);
         std::vector<int64_t> mask = tensor.data<int64_t>();
         std::vector<guint> dims = tensor.dims();
-        const cv::Size &mask_size{int(dims[1]), int(dims[2])};
+        const cv::Size &mask_size{int(dims[2]), int(dims[1])};
         cv::Rect2f box(rect.x, rect.y, rect.w, rect.h);
         prims.emplace_back(render::SemanticSegmantationMask(mask, mask_size, box));
     }


### PR DESCRIPTION
### Description

cv::Size takes (width, height), but both segmentation-mask branches in gvawatermark build it from tensor dims in (H, W) order, so non-square masks were read incorrect and displayed as striped lines. 
Swapped the indices in both: semantic segmentation branch dims are {1, H, W} -> Size(dims[2], dims[1]), instance segmentation branch dims are {H, W} -> Size(dims[1], dims[0]).

Fixes #1046 

### Any Newly Introduced Dependencies

nil.

### How Has This Been Tested?

Ran gvawatermark with segmentation model outputting rectangular dimensions.

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

