### PR TITLE
Fix g3dinference pointpillars test to run with score-threshold=0

### DIFF
--- a/tests/unit_tests/tests_gstgva/test_pipeline_g3dinference.py
+++ b/tests/unit_tests/tests_gstgva/test_pipeline_g3dinference.py
@@ -31,6 +31,9 @@ ALLOW_POINTPILLARS_DOWNLOAD = os.environ.get("G3DINFERENCE_ALLOW_DOWNLOAD", "").
 # Expected detections were captured from the openvino_contrib PointPillars assets at
 # revision f3c621350f93a31a08c7657fe75120e3038d15eb using demo_data/test/000002.bin.
 # z is the box CENTRE: g3dinference raises PointPillars' bottom-center z by h/2.
+# The list covers the full post-processing output, down to confidence 0.45, so the
+# pipeline under test must run with score-threshold=0. At the element's 0.7 default
+# the four lowest-scoring boxes are filtered out and only 6 detections are produced.
 EXPECTED_DETECTIONS = [
     {"label_id": 2, "confidence": 0.954, "bbox_3d": {"x": 10.403315544128418, "y": -4.837177753448486, "z": -0.7734637260437012, "w": 1.692104697227478, "l": 4.5549397468566895, "h": 1.5184109210968018, "yaw": -0.02542771026492119}},
     {"label_id": 2, "confidence": 0.936, "bbox_3d": {"x": 18.695310592651367, "y": 5.6205010414123535, "z": -1.3262365460395813, "w": 1.5274709463119507, "l": 3.4749011993408203, "h": 1.4211682081222534, "yaw": 1.534871220588684}},
@@ -482,7 +485,7 @@ class TestG3DInference(unittest.TestCase):
             f'multifilesrc location="{self.pc_pattern}" start-index={self.pc_index} stop-index={self.pc_index} '
             f'caps=application/octet-stream ! '
             f'g3dlidarparse ! '
-            f'g3dinference config="{self.config_file}" device=CPU ! '
+            f'g3dinference config="{self.config_file}" device=CPU score-threshold=0 ! '
             f'gvametaconvert add-tensor-data=true format=json json-indent=2 ! '
             f'gvametapublish file-format=2 file-path="{self.test_output}" ! '
             f'fakesink'


### PR DESCRIPTION
test_g3dinference_pointpillars_pipeline compares its output against EXPECTED_DETECTIONS, which lists the full post-processing output of demo_data/test/000002.bin down to confidence 0.45. The pipeline under test did not set score-threshold, so it ran at the element's 0.7 default and the four lowest-scoring boxes (0.552, 0.549, 0.530, 0.450) were filtered out, failing with "Expected 10 objects, got 6".

The element output is correct: rerunning the same pipeline with score-threshold=0 yields exactly the 10 expected detections with confidences [0.954, 0.936, 0.918, 0.914, 0.900, 0.820, 0.552, 0.549, 0.530, 0.450]. Only the test was missing the property.

Set score-threshold=0 in the pipeline and record the dependency between EXPECTED_DETECTIONS and the threshold so the two do not drift apart again.

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

