### PR TITLE
Potential fix for code scanning alert no. 287: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/documentation-check.yaml
+++ b/.github/workflows/documentation-check.yaml
@@ -29,9 +29,9 @@ jobs:
           fetch-depth: 0
           # Fetch tags
           fetch-tags: true
-          # Checkout the branch that triggered the workflow
-          # to avoid detached HEAD
-          ref: ${{ github.event.pull_request.head.sha || github.head_ref }}
+          # For pull_request, test PR head commit.
+          # For workflow_dispatch and other events, use the trusted triggering commit.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Check if should skip CI


### PR DESCRIPTION
Potential fix for [https://github.com/open-edge-platform/dlstreamer/security/code-scanning/287](https://github.com/open-edge-platform/dlstreamer/security/code-scanning/287)

General fix: do not execute untrusted PR/head code in a default-branch write-capable/manual-dispatch context. For this workflow, keep PR behavior as-is, but for `workflow_dispatch` force checkout of a trusted ref (the repository default branch / current SHA), not `github.head_ref`.

Best minimal fix in this file: update the checkout `ref` expression (line 34 region) so:
- On `pull_request`, use `github.event.pull_request.head.sha` (expected untrusted CI behavior).
- Otherwise (including `workflow_dispatch`), use `github.sha` (trusted commit associated with the workflow run context), avoiding user-influenced head refs.

Only `.github/workflows/documentation-check.yaml` needs editing; no imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
