### PR TITLE
Update Smart NVR Python sample

### DIFF
--- a/samples/gstreamer/python/smart_nvr/README.md
+++ b/samples/gstreamer/python/smart_nvr/README.md
@@ -71,9 +71,7 @@ curl -L -o 2431853-hd_1920_1080_25fps.mp4 \
 ### Prepare Model
 
 This sample expects `PekingU/rtdetr_v2_r50vd` in FP16 precision from Hugging Face for vehicle detection.
-
-Use the model conversion script in [scripts/download_models/](../../../../scripts/download_models/README.md) to prepare the model.
-Before running it, create and activate the dedicated model-download virtual environment described in [scripts/download_models/README.md](../../../../scripts/download_models/README.md).
+Use the [Hugging Face model conversion](../../../../scripts/download_models/README.md#1-hugging-face-conversion) to prepare the model.
 
 ## Run Sample Application
 

--- a/samples/gstreamer/python/smart_nvr/README.md
+++ b/samples/gstreamer/python/smart_nvr/README.md
@@ -15,8 +15,10 @@ graph LR
         A["filesrc (GStreamer)"] --> B["decodebin3 (GStreamer)"]
         B --> C["gvadetect (DLStreamer)"]
         C --> D["gvaanalytics_py (custom)"]
-        D --> E["gvawatermark (DLStreamer)"]
-        E --> F["gvarecorder_py (custom)"]
+        D --> E{output mode}
+        E -->|display| F["gvawatermark + autovideosink"]
+        E -->|file| G["gvawatermark + gvarecorder_py (custom)"]
+        E -->|json| H["gvametaconvert + gvametapublish + fakesink"]
 ```
 
 The sample uses the following set of pipeline elements: 
@@ -26,7 +28,8 @@ The sample uses the following set of pipeline elements:
 * __gvadetect__ - DLStreamer inference element that detects vehicles using the RTDETRv2 model
 * __gvaanalytics_py__ - Custom Python element that processes object detection results and identifies lane-hogging vehicles
 * __gvawatermark__ - DLStreamer element that renders detection results and custom objects (lane-hogging vehicles) on video frames
-* __gvarecorder_py__ - Custom Python element that segments the video into 10-second chunks and stores metadata for each segment 
+* __gvarecorder_py__ - Custom Python element that segments the video into 10-second chunks and stores metadata for each segment (used in `file` output mode)
+* __gvametaconvert / gvametapublish__ - DLStreamer elements that serialize detection metadata to JSON Lines format (used in `json` output mode)
 
 ## Prerequisites
 
@@ -56,7 +59,7 @@ Install DLStreamer on the host (see [DLStreamer Installation Guide](../../../../
 cd samples/gstreamer/python/smart_nvr
 ```
 
-### Download Video and Prepare Model
+### Download Video
 
 Download example video file:
 
@@ -65,48 +68,58 @@ curl -L -o 2431853-hd_1920_1080_25fps.mp4 \
     "https://videos.pexels.com/video-files/2431853/2431853-hd_1920_1080_25fps.mp4"
 ```
 
-Export the RTDETRv2 detection model to OpenVINO IR format:
+### Prepare Model
 
-```sh
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
-optimum-cli export onnx --model PekingU/rtdetr_v2_r50vd \
-    --task object-detection --opset 18 --width 640 --height 640 rtdetr_v2_r50vd
-hf download PekingU/rtdetr_v2_r50vd --include preprocessor_config.json --local-dir rtdetr_v2_r50vd
-ovc rtdetr_v2_r50vd/model.onnx --output_model rtdetr_v2_r50vd/model
-deactivate
-```
+This sample expects `PekingU/rtdetr_v2_r50vd` in FP16 precision from Hugging Face for vehicle detection.
+
+Use the model conversion script in [scripts/download_models/](../../../../scripts/download_models/README.md) to prepare the model.
+Before running it, create and activate the dedicated model-download virtual environment described in [scripts/download_models/README.md](../../../../scripts/download_models/README.md).
 
 ## Run Sample Application
 
 ```sh
 python3 smart_nvr.py \
     --input 2431853-hd_1920_1080_25fps.mp4 \
-    --model rtdetr_v2_r50vd/model.xml
+    --model "MODELS_PATH/PekingU_rtdetr_v2_r50vd.xml"
 ```
 
-Run `python3 smart_nvr.py --help` to see available options (input file, device, threshold, etc.).
+Run `python3 smart_nvr.py --help` to see all available options.
 
-### Inspecting Output
+### Output Modes
 
-The sample generates output video chunks (*.mp4) and corresponding metadata files (*.txt):
+Control the output with `--output` (default: `display`):
 
+| Mode | Description |
+|---|---|
+| `display` | Renders watermarked frames to screen via `autovideosink` |
+| `file` | Segments video into MP4 chunks with per-chunk metadata files via `gvarecorder_py` |
+| `json` | Writes detection metadata as JSON Lines to `output.json` via `gvametapublish` |
+
+**Display (default):**
 ```sh
-output-00.txt
-output-00.mp4
-output-01.txt
-output-01.mp4
+python3 smart_nvr.py --input video.mp4 --model model.xml --output display
+```
+
+**File recording** (use `--output-location` to set the output path, `--max-time` for chunk duration):
+```sh
+python3 smart_nvr.py --input video.mp4 --model model.xml --output file \
+    --output-location output.mp4 --max-time 10
+```
+
+The sample generates output video chunks and corresponding metadata files:
+```
+output-00.txt  output-00.mp4
+output-01.txt  output-01.mp4
 ...
 ```
+Each metadata file lists the detected objects for that segment, e.g. `Objects: ['car', 'hogging', 'truck']`.
+Search for `hogging` entries to find lane-hogging events, then review the matching MP4 segment.
 
-Each metadata file contains the detected objects and events for its corresponding video segment:
-
+**JSON metadata:**
 ```sh
-Objects: ['car', 'hogging', 'truck']
+python3 smart_nvr.py --input video.mp4 --model model.xml --output json
 ```
-
-To identify lane-hogging events, search the metadata files for 'hogging' entries, then review the corresponding video segment to observe the detected behavior.
+Outputs `output.json` in JSON Lines format, one record per frame.
 
 ## How It Works
 
@@ -120,8 +133,8 @@ pipeline = Gst.parse_launch(
                 f'filesrc location="{video_file}" ! decodebin3 caps="video/x-raw(ANY)" ! '
                 f'gvadetect model="{detection_model}" device={args.device} '
                 f'batch-size={args.batch_size} threshold={args.threshold} ! queue ! '
-                f'gvaanalytics_py distance=500 angle=-135,-45 ! gvafpscounter ! gvawatermark ! '
-                f'gvarecorder_py location="{args.output}" max-time={args.max_time}')
+                f'gvaanalytics_py distance=500 angle=-135,-45 ! queue ! '
+                f'{sink}')  # sink depends on --output mode
 ```
 
 ### Custom Analytics Element

--- a/samples/gstreamer/python/smart_nvr/README.md
+++ b/samples/gstreamer/python/smart_nvr/README.md
@@ -89,11 +89,11 @@ Run `python3 smart_nvr.py --help` to see all available options.
 
 Control the output with `--output` (default: `display`):
 
-| Mode | Description |
-|---|---|
-| `display` | Renders watermarked frames to screen via `videoconvert` + `autovideosink` |
-| `file` | Segments video into MP4 chunks with per-chunk metadata files via `gvarecorder_py` |
-| `json` | Writes detection metadata as JSON Lines to `output.json` via `gvametapublish` |
+| Mode | Device support | Description |
+|---|---|---|
+| `display` | CPU, GPU, NPU | Renders watermarked frames to screen via `videoconvert` + `autovideosink` |
+| `file` | GPU (VA-API encoder); CPU/NPU require `openh264enc` | Segments video into MP4 chunks with per-chunk metadata files via `gvarecorder_py` |
+| `json` | CPU, GPU, NPU | Writes detection metadata as JSON Lines to `output.json` via `gvametapublish` |
 
 **Display (default):**
 ```sh

--- a/samples/gstreamer/python/smart_nvr/README.md
+++ b/samples/gstreamer/python/smart_nvr/README.md
@@ -80,8 +80,12 @@ Before running it, create and activate the dedicated model-download virtual envi
 ```sh
 python3 smart_nvr.py \
     --input 2431853-hd_1920_1080_25fps.mp4 \
-    --model "MODELS_PATH/PekingU_rtdetr_v2_r50vd.xml"
+    --model models/public/PekingU_rtdetr_v2_r50vd/FP16/PekingU_rtdetr_v2_r50vd.xml
 ```
+
+If `--model` is omitted, it defaults to `$MODELS_PATH/public/PekingU_rtdetr_v2_r50vd/FP16/PekingU_rtdetr_v2_r50vd.xml`.
+
+> **Note:** Replace the `--model` path with the actual location where you downloaded the model in the [Prepare Model](#prepare-model) step.
 
 Run `python3 smart_nvr.py --help` to see all available options.
 

--- a/samples/gstreamer/python/smart_nvr/README.md
+++ b/samples/gstreamer/python/smart_nvr/README.md
@@ -16,7 +16,7 @@ graph LR
         B --> C["gvadetect (DLStreamer)"]
         C --> D["gvaanalytics_py (custom)"]
         D --> E{output mode}
-        E -->|display| F["gvawatermark + autovideosink"]
+        E -->|display| F["gvawatermark + videoconvert + autovideosink"]
         E -->|file| G["gvawatermark + gvarecorder_py (custom)"]
         E -->|json| H["gvametaconvert + gvametapublish + fakesink"]
 ```
@@ -91,7 +91,7 @@ Control the output with `--output` (default: `display`):
 
 | Mode | Description |
 |---|---|
-| `display` | Renders watermarked frames to screen via `autovideosink` |
+| `display` | Renders watermarked frames to screen via `videoconvert` + `autovideosink` |
 | `file` | Segments video into MP4 chunks with per-chunk metadata files via `gvarecorder_py` |
 | `json` | Writes detection metadata as JSON Lines to `output.json` via `gvametapublish` |
 
@@ -130,7 +130,7 @@ The pipeline is configured with the downloaded video file and detection model, a
 
 ```code
 pipeline = Gst.parse_launch(
-                f'filesrc location="{video_file}" ! decodebin3 caps="video/x-raw(ANY)" ! '
+                f'filesrc location="{video_file}" ! decodebin3 ! '
                 f'gvadetect model="{detection_model}" device={args.device} '
                 f'batch-size={args.batch_size} threshold={args.threshold} ! queue ! '
                 f'gvaanalytics_py distance=500 angle=-135,-45 ! queue ! '

--- a/samples/gstreamer/python/smart_nvr/README.md
+++ b/samples/gstreamer/python/smart_nvr/README.md
@@ -91,9 +91,9 @@ Control the output with `--output` (default: `display`):
 
 | Mode | Device support | Description |
 |---|---|---|
-| `display` | CPU, GPU, NPU | Renders watermarked frames to screen via `videoconvert` + `autovideosink` |
-| `file` | GPU (VA-API encoder); CPU/NPU require `openh264enc` | Segments video into MP4 chunks with per-chunk metadata files via `gvarecorder_py` |
-| `json` | CPU, GPU, NPU | Writes detection metadata as JSON Lines to `output.json` via `gvametapublish` |
+| `display` | CPU, GPU | Renders watermarked frames to screen via `videoconvert` + `autovideosink` |
+| `file` | GPU (VA-API encoder); CPU requires `openh264enc` | Segments video into MP4 chunks with per-chunk metadata files via `gvarecorder_py` |
+| `json` | CPU, GPU | Writes detection metadata as JSON Lines to `output.json` via `gvametapublish` |
 
 **Display (default):**
 ```sh

--- a/samples/gstreamer/python/smart_nvr/plugins/python/gvaRecorder.py
+++ b/samples/gstreamer/python/smart_nvr/plugins/python/gvaRecorder.py
@@ -53,9 +53,12 @@ class Recorder(Gst.Bin):
     def __init__(self):
         super(Recorder, self).__init__()
 
-        # construct pipeline: videoconvert -> vah264enc -> h264parse -> splitmuxsink
+        # construct pipeline: videoconvert -> vah264enc (falls back to openh264enc) -> h264parse -> splitmuxsink
         self._convert = Gst.ElementFactory.make("videoconvert", "convert")
-        self._vah264enc = Gst.ElementFactory.make("vah264enc", "encoder")
+        self._vah264enc = Gst.ElementFactory.make("vah264enc", "encoder") or \
+            Gst.ElementFactory.make("openh264enc", "encoder")
+        if self._vah264enc is None:
+            raise RuntimeError("No H.264 encoder found: install vah264enc (GPU) or openh264enc (CPU)")
         self._h264parse = Gst.ElementFactory.make("h264parse", "h264parse")
         self._filesink = Gst.ElementFactory.make("splitmuxsink", "splitmuxsink")
         self.add(self._convert)

--- a/samples/gstreamer/python/smart_nvr/smart_nvr.py
+++ b/samples/gstreamer/python/smart_nvr/smart_nvr.py
@@ -34,7 +34,7 @@ def parse_args():
     p = argparse.ArgumentParser(description="Smart NVR — Lane Hogging Detection")
     p.add_argument("--input", required=True, help="Path to input video file")
     p.add_argument("--model", required=True, help="Path to detection model .xml")
-    p.add_argument("--device", default="GPU", choices=["CPU", "GPU", "NPU"],
+    p.add_argument("--device", default="GPU", choices=["CPU", "GPU"],
                    help="Inference device (default: GPU)")
     p.add_argument("--output", default="display", choices=["display", "json", "file"],
                    help="Output mode: display, json, or file (default: display)")

--- a/samples/gstreamer/python/smart_nvr/smart_nvr.py
+++ b/samples/gstreamer/python/smart_nvr/smart_nvr.py
@@ -25,6 +25,9 @@ from gi.repository import GLib, Gst  # pylint: disable=no-name-in-module,wrong-i
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 
+# Default detection model location, relative to $MODELS_PATH (default: ./models).
+DEFAULT_MODEL_REL = "public/PekingU_rtdetr_v2_r50vd/FP16/PekingU_rtdetr_v2_r50vd.xml"
+
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -33,7 +36,8 @@ def parse_args():
     """Parse command-line arguments."""
     p = argparse.ArgumentParser(description="Smart NVR — Lane Hogging Detection")
     p.add_argument("--input", required=True, help="Path to input video file")
-    p.add_argument("--model", required=True, help="Path to detection model .xml")
+    p.add_argument("--model", default=None,
+                   help="Path to detection model .xml (default: $MODELS_PATH/" + DEFAULT_MODEL_REL + ")")
     p.add_argument("--device", default="GPU", choices=["CPU", "GPU"],
                    help="Inference device (default: GPU)")
     p.add_argument("--output", default="display", choices=["display", "json", "file"],
@@ -111,7 +115,8 @@ def main():
 
     # Prepare assets
     video_file = ensure_file(args.input, "input video")
-    detection_model = ensure_file(args.model, "detection model")
+    model_path = args.model or os.path.join(os.environ.get("MODELS_PATH", "./models"), DEFAULT_MODEL_REL)
+    detection_model = ensure_file(model_path, "detection model")
 
     # Build sink based on output mode
     if args.output == "json":

--- a/samples/gstreamer/python/smart_nvr/smart_nvr.py
+++ b/samples/gstreamer/python/smart_nvr/smart_nvr.py
@@ -35,8 +35,11 @@ def parse_args():
     p.add_argument("--input", required=True, help="Path to input video file")
     p.add_argument("--model", required=True, help="Path to detection model .xml")
     p.add_argument("--device", default="GPU", help="Inference device (default: GPU)")
-    p.add_argument("--output", default="output.mp4", help="Output file location pattern (default: output.mp4)")
-    p.add_argument("--max-time", type=int, default=10, help="Chunk duration in seconds (default: 10)")
+    p.add_argument("--output", default="display", choices=["display", "json", "file"],
+                   help="Output mode: display, json, or file (default: display)")
+    p.add_argument("--output-location", default="output.mp4",
+                   help="Output file path for file mode (default: output.mp4)")
+    p.add_argument("--max-time", type=int, default=10, help="Chunk duration in seconds for file mode (default: 10)")
     p.add_argument("--threshold", type=float, default=0.7, help="Detection confidence threshold (default: 0.7)")
     p.add_argument("--batch-size", type=int, default=4, help="Inference batch size (default: 4)")
     return p.parse_args()
@@ -109,13 +112,28 @@ def main():
     video_file = ensure_file(args.input, "input video")
     detection_model = ensure_file(args.model, "detection model")
 
+    # Build sink based on output mode
+    if args.output == "json":
+        sink = (
+            "gvametaconvert add-tensor-data=true ! "
+            "gvametapublish file-format=json-lines file-path=output.json ! "
+            "fakesink async=false"
+        )
+    elif args.output == "file":
+        sink = (
+            f"gvafpscounter ! gvawatermark ! "
+            f'gvarecorder_py location="{args.output_location}" max-time={args.max_time}'
+        )
+    else:
+        sink = "gvafpscounter ! gvawatermark ! autovideosink sync=false"
+
     # Build pipeline
     pipe = (
         f'filesrc location="{video_file}" ! decodebin3 caps="video/x-raw(ANY)" ! '
         f'gvadetect model="{detection_model}" device={args.device} '
         f"batch-size={args.batch_size} threshold={args.threshold} ! queue ! "
-        f"gvaanalytics_py distance=500 angle=-135,-45 ! gvafpscounter ! gvawatermark ! "
-        f'gvarecorder_py location="{args.output}" max-time={args.max_time}'
+        f"gvaanalytics_py distance=500 angle=-135,-45 ! queue ! "
+        f"{sink}"
     )
     print(f'Pipeline: "{pipe}"')
     pipeline = Gst.parse_launch(pipe)

--- a/samples/gstreamer/python/smart_nvr/smart_nvr.py
+++ b/samples/gstreamer/python/smart_nvr/smart_nvr.py
@@ -34,7 +34,8 @@ def parse_args():
     p = argparse.ArgumentParser(description="Smart NVR — Lane Hogging Detection")
     p.add_argument("--input", required=True, help="Path to input video file")
     p.add_argument("--model", required=True, help="Path to detection model .xml")
-    p.add_argument("--device", default="GPU", help="Inference device (default: GPU)")
+    p.add_argument("--device", default="GPU", choices=["CPU", "GPU", "NPU"],
+                   help="Inference device (default: GPU)")
     p.add_argument("--output", default="display", choices=["display", "json", "file"],
                    help="Output mode: display, json, or file (default: display)")
     p.add_argument("--output-location", default="output.mp4",

--- a/samples/gstreamer/python/smart_nvr/smart_nvr.py
+++ b/samples/gstreamer/python/smart_nvr/smart_nvr.py
@@ -125,11 +125,11 @@ def main():
             f'gvarecorder_py location="{args.output_location}" max-time={args.max_time}'
         )
     else:
-        sink = "gvafpscounter ! gvawatermark ! autovideosink sync=false"
+        sink = "gvafpscounter ! gvawatermark ! videoconvert ! autovideosink sync=false"
 
     # Build pipeline
     pipe = (
-        f'filesrc location="{video_file}" ! decodebin3 caps="video/x-raw(ANY)" ! '
+        f'filesrc location="{video_file}" ! decodebin3 ! '
         f'gvadetect model="{detection_model}" device={args.device} '
         f"batch-size={args.batch_size} threshold={args.threshold} ! queue ! "
         f"gvaanalytics_py distance=500 angle=-135,-45 ! queue ! "


### PR DESCRIPTION
### Description

- **Output modes:** --output is now a mode selector (display / json / file) instead of a hardcoded recorder file path. json mode writes detection metadata as JSON Lines via gvametaconvert + gvametapublish, making the sample comparable against ground truth in the test framework. --output-location replaces the old --output filepath for file mode.
- **Pipeline fixes:** removed caps="video/x-raw(ANY)" from decodebin3 (caused not-linked errors with MP4 files containing audio); added videoconvert before autovideosink in display mode to handle GPU memory formats output by gvawatermark.
- **Device support:** --device now has choices=["CPU", "GPU"]; gvaRecorder.py falls back from vah264enc to openh264enc so file mode works on CPU.
- **README**: updated to reflect all of the above; model preparation section aligned with download_hf_models.py convention used by other samples (replacing manual optimum-cli + ovc steps); corrected model precision to FP16.

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

