### PR TITLE
Fix reshaping model with user provided shape

### DIFF
--- a/src/monolithic/gst/inference_elements/base/inference_impl.cpp
+++ b/src/monolithic/gst/inference_elements/base/inference_impl.cpp
@@ -423,7 +423,8 @@ std::string three_doubles_to_str(const std::array<double, 3> &v) {
 }
 
 void UpdateConfigWithLayerInfo(const std::vector<ModelInputProcessorInfo::Ptr> &model_input_processor_info,
-                               std::map<std::string, std::map<std::string, std::string>> &config) {
+                               std::map<std::string, std::map<std::string, std::string>> &config,
+                               bool user_provided_reshape = false) {
     std::map<std::string, std::string> input_layer_precision;
     std::map<std::string, std::string> input_format;
     for (const ModelInputProcessorInfo::Ptr &preproc : model_input_processor_info) {
@@ -592,10 +593,22 @@ void UpdateConfigWithLayerInfo(const std::vector<ModelInputProcessorInfo::Ptr> &
     // This enables the backend's standard pre-compile reshape handling, even when the resolved size happens to
     // match the model's original input shape and the reshape becomes an effective no-op.
     if (resolved_static_reshape_shape.first && resolved_static_reshape_shape.second) {
-        config[KEY_BASE][KEY_RESHAPE] = "1";
-        config[KEY_BASE][KEY_RESHAPE_STATIC] = "1";
-        config[KEY_BASE][KEY_RESHAPE_WIDTH] = std::to_string(resolved_static_reshape_shape.first);
-        config[KEY_BASE][KEY_RESHAPE_HEIGHT] = std::to_string(resolved_static_reshape_shape.second);
+        if (user_provided_reshape) {
+            // User explicitly set reshape dimensions
+            // SKIP model metadata overwrite and respect user's values
+            std::string current_reshape_static_str = config[KEY_BASE][KEY_RESHAPE_STATIC];
+            if (current_reshape_static_str.empty()) {
+                config[KEY_BASE][KEY_RESHAPE_STATIC] = "1";
+                config[KEY_BASE][KEY_RESHAPE] = "1";
+            }
+        } else {
+            // No user-specified reshape, apply model metadata values as defaults
+            // This allows model-proc or metadata.yaml to provide reshape configuration
+            config[KEY_BASE][KEY_RESHAPE] = "1";
+            config[KEY_BASE][KEY_RESHAPE_STATIC] = "1";
+            config[KEY_BASE][KEY_RESHAPE_WIDTH] = std::to_string(resolved_static_reshape_shape.first);
+            config[KEY_BASE][KEY_RESHAPE_HEIGHT] = std::to_string(resolved_static_reshape_shape.second);
+        }
     }
 }
 
@@ -894,7 +907,9 @@ InferenceImpl::Model InferenceImpl::CreateModel(GvaBaseInference *gva_base_infer
         ie_config[KEY_BASE]["frame-width"] = std::to_string(gva_base_inference->info->width);
         ie_config[KEY_BASE]["frame-height"] = std::to_string(gva_base_inference->info->height);
     }
-    UpdateConfigWithLayerInfo(model.input_processor_info, ie_config);
+    // Determine if user explicitly provided reshape dimensions (non-zero width or height)
+    bool user_provided_reshape = (gva_base_inference->reshape_width != 0) || (gva_base_inference->reshape_height != 0);
+    UpdateConfigWithLayerInfo(model.input_processor_info, ie_config, user_provided_reshape);
     setPreprocessorType(ie_config, model.input_processor_info, gva_base_inference->info);
     memory_type =
         GetMemoryType(GetMemoryType(static_cast<CapsFeature>(std::stoi(ie_config[KEY_BASE][KEY_CAPS_FEATURE]))),


### PR DESCRIPTION
### Description

User provided reshape width and height could be overwritten by model's parameters - this PR is fixing this behavior.

### Any Newly Introduced Dependencies

N/A
### How Has This Been Tested?

Verified if correct shape are used (docker deployment)

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

