### PR TITLE
Loitering sample - update sample's paths resolving and models section in README

### DIFF
--- a/samples/gstreamer/python/loitering_detection/README.md
+++ b/samples/gstreamer/python/loitering_detection/README.md
@@ -125,13 +125,6 @@ This sample expects `yolo11s` in FP16 precision from Ultralytics for object dete
 Use the model conversion script in [scripts/download_models/](../../../../scripts/download_models/README.md) to prepare the model.
 Before running it, create and activate the dedicated model-download virtual environment described in [scripts/download_models/README.md](../../../../scripts/download_models/README.md).
 
-Set `MODELS_PATH` to the directory where models are downloaded, then run:
-
-```sh
-export MODELS_PATH="$HOME/models"
-python3 download_ultralytics_models.py --model yolo11s --outdir "${MODELS_PATH}/public/yolo11s/FP16" --half
-```
-
 ### Execution
 
 You can run the sample using the provided shell script.

--- a/samples/gstreamer/python/loitering_detection/README.md
+++ b/samples/gstreamer/python/loitering_detection/README.md
@@ -118,19 +118,19 @@ Install DLStreamer on the host (see [DLStreamer Installation Guide](../../../../
 cd /opt/intel/dlstreamer/samples/gstreamer/python/loitering_detection
 ```
 
-### Create folder and download model from Ultralytics
+### Prepare Model
+
+This sample expects `yolo11s` in FP16 precision from Ultralytics for object detection.
+
+Use the model conversion script in [scripts/download_models/](../../../../scripts/download_models/README.md) to prepare the model.
+Before running it, create and activate the dedicated model-download virtual environment described in [scripts/download_models/README.md](../../../../scripts/download_models/README.md).
+
+Set `MODELS_PATH` to the directory where models are downloaded, then run:
 
 ```sh
-export MODELS_PATH=./models
-mkdir -p ${MODEL_PATH}
-
-python3 -m venv venv  
-source venv/bin/activate
-pip install -r /opt/intel/dlstreamer/scripts/download_models/requirements_download_ultralytics_models.txt 
-
-python3 /opt/intel/dlstreamer/scripts/download_models/download_ultralytics_models.py --model yolo11s --outdir ${MODELS_PATH}/public/yolo11s/FP16 --half
+export MODELS_PATH="$HOME/models"
+python3 download_ultralytics_models.py --model yolo11s --outdir "${MODELS_PATH}/public/yolo11s/FP16" --half
 ```
-> **Note:** This may take several seconds depending on your network speed.
 
 ### Execution
 
@@ -146,7 +146,7 @@ Parameter details:
 - `INPUT`: Input video file path or URL.
   - Default: `https://github.com/open-edge-platform/edge-ai-resources/raw/refs/heads/main/videos/VIRAT_S_000101.mp4`
 - `CONFIG_FILE`: Zone configuration file for loitering detection.
-  - Default: `./virat_s_000101-config.json`
+  - Default: `<sample_dir>/virat_s_000101-config.json`
 - `MODEL`: Path to OpenVINO IR XML model used by `gvadetect`.
   - Default: `${MODELS_PATH}/public/yolo11s/FP16/yolo11s.xml`
   - The default is built from the `MODELS_PATH` environment variable (see below).

--- a/samples/gstreamer/python/loitering_detection/README.md
+++ b/samples/gstreamer/python/loitering_detection/README.md
@@ -121,9 +121,7 @@ cd /opt/intel/dlstreamer/samples/gstreamer/python/loitering_detection
 ### Prepare Model
 
 This sample expects `yolo11s` in FP16 precision from Ultralytics for object detection.
-
-Use the model conversion script in [scripts/download_models/](../../../../scripts/download_models/README.md) to prepare the model.
-Before running it, create and activate the dedicated model-download virtual environment described in [scripts/download_models/README.md](../../../../scripts/download_models/README.md).
+Use the [Ultralytics model conversion](../../../../scripts/download_models/README.md#2-ultralytics-conversion) to prepare the model.
 
 ### Execution
 

--- a/samples/gstreamer/python/loitering_detection/loitering_detection.sh
+++ b/samples/gstreamer/python/loitering_detection/loitering_detection.sh
@@ -20,7 +20,7 @@ Parameters:
                 Default: https://github.com/open-edge-platform/edge-ai-resources/raw/refs/heads/main/videos/VIRAT_S_000101.mp4
   
   CONFIG_FILE - Zone configuration file for loitering detection
-                Default: ./virat_s_000101-config.json
+                Default: <script_dir>/virat_s_000101-config.json
   
   MODEL       - Detection model (path to .xml file for OpenVINO format)
                 Default: \${MODELS_PATH}/public/yolo11s/FP16/yolo11s.xml
@@ -67,18 +67,20 @@ if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     usage
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Configuration parameters
 MODELS_PATH=${MODELS_PATH:-./models}  # Path to models directory (e.g., /path/to/omz_models)
 INPUT=${1:-https://github.com/open-edge-platform/edge-ai-resources/raw/refs/heads/main/videos/VIRAT_S_000101.mp4}
-CONFIG_FILE=${2:-./virat_s_000101-config.json}
+CONFIG_FILE=${2:-${SCRIPT_DIR}/virat_s_000101-config.json}
 MODEL=${3:-${MODELS_PATH}/public/yolo11s/FP16/yolo11s.xml} # Detection model (YOLO, SSD, etc.)
 DEVICE=${4:-"GPU"}
 OUTPUT=${5:-loitering_detection_output.mp4}  # Output video file (H.264 MP4)
 JSON_METADATA=${6:-loitering_detection_output.json}  # Output file for analytics metadata (JSON Lines format)
 
-export GST_PLUGIN_PATH=./plugins:${GST_PLUGIN_PATH}
+export GST_PLUGIN_PATH="${SCRIPT_DIR}/plugins:${GST_PLUGIN_PATH}"
 export GI_TYPELIB_PATH=/opt/intel/dlstreamer/gstreamer/lib/girepository-1.0:/opt/intel/dlstreamer/lib/girepository-1.0:/usr/lib/x86_64-linux-gnu/girepository-1.0
-export PYTHONPATH=./plugins:/opt/intel/dlstreamer/python:/opt/intel/dlstreamer/gstreamer/lib/python3/dist-packages:${PYTHONPATH}
+export PYTHONPATH="${SCRIPT_DIR}/plugins:/opt/intel/dlstreamer/python:/opt/intel/dlstreamer/gstreamer/lib/python3/dist-packages:${PYTHONPATH}"
 
 rm -rf ~/.cache/gstreamer-1.0/registry.x86_64.bin
 

--- a/samples/gstreamer/python/loitering_detection/loitering_detection.sh
+++ b/samples/gstreamer/python/loitering_detection/loitering_detection.sh
@@ -143,7 +143,7 @@ gst-launch-1.0 -e ${SOURCE_ELEMENT} ! decodebin3 ! \
     gvatrack tracking-type=zero-term ! queue ! \
     gvaanalytics config=${CONFIG_FILE} evaluation-point=bottom-center ! queue ! \
     loitering_watermark loitering-threshold=5.0 dashboard-pos="750,60" ! queue ! \
-    gvametaconvert json-indent=2 ! gvametapublish file-format=json file-path=${JSON_METADATA} ! queue !  \
+    gvametaconvert ! gvametapublish file-format=json-lines file-path=${JSON_METADATA} ! queue !  \
     gvawatermark device=${WATERMARK_DEVICE} ! \
     gvafpscounter ! queue ! \
     ${ENCODER} bitrate=1024 ! h264parse ! mp4mux ! filesink location=${OUTPUT} 


### PR DESCRIPTION
### Description

- Script-relative paths: loitering_detection.sh now derives SCRIPT_DIR from its own location and resolves the default config, plugins/ (GST_PLUGIN_PATH/PYTHONPATH) against it. Previously these were relative to the caller's working directory, so running the script from anywhere but the sample folder failed (missing loitering_watermark plugin, config-not-found warning).
- JSON Lines output: the pipeline now uses gvametaconvert ! gvametapublish file-format=json-lines instead of pretty-printed json-indent=2 / file-format=json, giving one metadata record per frame (consistent with other samples and parseable by downstream tooling/tests).
- README model section: replaced the inline venv/pip/download_ultralytics_models.py steps with a concise description (yolo11s FP16 from Ultralytics) plus a reference to download_models, and corrected the config/default path wording to reflect the script-relative default.

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

