### PR TITLE
Optimizer: power sampling and proper keyboard listening thread closure fix

### DIFF
--- a/scripts/optimizer/__main__.py
+++ b/scripts/optimizer/__main__.py
@@ -188,6 +188,9 @@ def main() -> int:
     except KeyboardInterrupt:
         logger.info("Execution stopped, closing down.")
     finally:
+        # sleeping here in case the keyboard listening thread hasn't started yet 
+        # when an error happens, otherwise it could ignore the stop_listening() signal
+        time.sleep(1)
         stop_listening()
         if args.output:
             with open(args.output, 'w', encoding='utf-8') as f:

--- a/scripts/optimizer/optimizer.py
+++ b/scripts/optimizer/optimizer.py
@@ -290,8 +290,6 @@ class DLSOptimizer:
                         best_result = result.copy()
                         best_pipeline = pipeline
 
-                    logger.info(str(result))
-
                     yield pipeline, result
 
                 except TestHalt:
@@ -342,6 +340,8 @@ class DLSOptimizer:
             start_time = time.time()
             power_total = 0.0
             power_samples = 0
+            power_sampling_delay = 0.5
+            last_power_sample = time.time()
             while not terminate:
                 if self._paused:
                     raise TestHalt("Interrupt signal received, halting test run")
@@ -374,7 +374,8 @@ class DLSOptimizer:
                 if cur_time - start_time > sample_duration:
                     terminate = True
 
-                if self._metrics_url is not None:
+                if self._metrics_url is not None and cur_time - last_power_sample > power_sampling_delay:
+                    last_power_sample = cur_time
                     try:
                         resp = requests.get(self._metrics_url, timeout=1)
                         resp.raise_for_status()


### PR DESCRIPTION
### Description

- Currently power sampling has a bias towards samples collected at the beginning of pipeline running. Added a delay to more evenly spread out the sampling during pipeline testing.
- Sometimes the thread listening for keyboard input wouldn't be running yet when the application exits, causing it to ignore the stop signal and causing a hang. Added a tiny delay before application exit to alleviate issue.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

