### PR TITLE
Rewrite the gvawatermark device=GPU render path to draw directly into NV12 VA surfaces

### DIFF
--- a/docs/user-guide/elements/gvawatermark.md
+++ b/docs/user-guide/elements/gvawatermark.md
@@ -79,7 +79,6 @@ Element Properties:
                         * enable-blur=<bool> enable ROI blurring for privacy protection, default false
                           NOTE : Blurring is applied only when "enable-blur=true"; if no "show-blur-roi" / "hide-blur-roi" filters are set, all ROIs are blurred
                           NOTE : show-blur-roi takes precedence over hide-blur-roi when both are specified
-                          NOTE : this option is supported only for CPU for now.
                         * show-blur-roi=<string> colon-separated list of object labels to blur (e.g., "face:person")
                         * hide-blur-roi=<string> colon-separated list of labels to exclude from blurring (show-blur-roi takes precedence)
                         * text-x=<float> x position (pixels) for full-frame text (e.g. from gvagenai), default 0
@@ -189,7 +188,7 @@ e.g `displ-cfg=show-labels=true,hide-roi=car`
 
 ### Blur Feature
 
-The gvawatermark element supports privacy protection through region of interest (ROI) blurring using OpenCV GaussianBlur with a dynamic kernel size as ~1/5 of each ROI dimension (minimum 7, always odd)
+The gvawatermark element supports privacy protection through region of interest (ROI) blurring using a Gaussian blur with a dynamic kernel size as ~1/5 of each ROI dimension (minimum 7, always odd)
 so the blur strength scales with the region. This feature is useful for anonymizing faces, license plates, or other sensitive content in video streams.
 
 #### Blur Configuration Parameters
@@ -251,7 +250,12 @@ displ-cfg=enable-blur=true,show-blur-roi=person:face,color-idx=0,font-scale=0.8
 
 ### Performance consideration
 
-**currently objects blur supported only on CPU**
+Blurring runs on whichever device the element is set to, including `device=GPU`.
+
+Unlike the rest of the watermark, the cost of a blur is proportional to the area
+of the regions being blurred, on either device. Blurring a large share of the
+frame is therefore expensive no matter the device, and gets more so with
+resolution.
 
 ### Configuration Examples
 

--- a/src/monolithic/gst/elements/CMakeLists.txt
+++ b/src/monolithic/gst/elements/CMakeLists.txt
@@ -15,6 +15,20 @@ pkg_check_modules(GSTRTP gstreamer-rtp-1.0 REQUIRED)
 if(NOT MSVC)
   pkg_check_modules(GSTVA REQUIRED IMPORTED_TARGET gstreamer-va-1.0)
 endif()
+
+# gvawatermark renders straight into VA NV12 planes through OpenCL when both VA
+# and OpenCL are available; without them the element keeps its CPU-only path.
+set(ENABLE_GVAWATERMARK_GPU OFF)
+if(NOT MSVC)
+    find_package(OpenCL QUIET)
+    pkg_check_modules(LIBVA libva)
+    if(OpenCL_FOUND AND LIBVA_FOUND)
+        set(ENABLE_GVAWATERMARK_GPU ON)
+        message(STATUS "gvawatermark: OpenCL NV12 renderer enabled")
+    else()
+        message(STATUS "gvawatermark: OpenCL NV12 renderer disabled (OpenCL or libva not found)")
+    endif()
+endif()
 if(${ENABLE_AUDIO_INFERENCE_ELEMENTS})
         pkg_check_modules(GSTAUDIO gstreamer-audio-1.0>=1.16 REQUIRED)
 endif()
@@ -57,6 +71,13 @@ file (GLOB MAIN_HEADERS
     gvafpsthrottle/*.hpp
     gvaanalytics/*.h
 )
+
+if(ENABLE_GVAWATERMARK_GPU)
+    file (GLOB WATERMARK_GPU_SRC gvawatermark/renderer/gpu/*.cpp)
+    file (GLOB WATERMARK_GPU_HEADERS gvawatermark/renderer/gpu/*.h)
+    list (APPEND MAIN_SRC ${WATERMARK_GPU_SRC})
+    list (APPEND MAIN_HEADERS ${WATERMARK_GPU_HEADERS})
+endif()
 
 if(${ENABLE_AUDIO_INFERENCE_ELEMENTS})
     file (GLOB AUDIO_SRC
@@ -122,6 +143,17 @@ if(NOT MSVC)
         ${GSTVA_LIBRARIES}
         dlstreamer_vaapi
     )
+endif()
+
+if(ENABLE_GVAWATERMARK_GPU)
+    target_include_directories(${TARGET_NAME}
+    PUBLIC
+        gvawatermark/renderer/gpu
+    PRIVATE
+        ${LIBVA_INCLUDE_DIRS}
+    )
+    target_link_libraries(${TARGET_NAME} PRIVATE OpenCL::OpenCL ${LIBVA_LIBRARIES})
+    target_compile_definitions(${TARGET_NAME} PUBLIC ENABLE_GVAWATERMARK_GPU)
 endif()
 
 if(${ENABLE_AUDIO_INFERENCE_ELEMENTS})

--- a/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
+++ b/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
@@ -393,9 +393,9 @@ static gboolean gst_gva_watermark_impl_set_caps(GstBaseTransform *trans, GstCaps
 #endif
 
     try {
-        gvawatermark->impl = std::make_shared<Impl>(&gvawatermark->info, mem_type, GST_ELEMENT(trans),
-                                                    gvawatermark->displ_avgfps, gvawatermark->displ_cfg,
-                                                    gvawatermark->device);
+        gvawatermark->impl =
+            std::make_shared<Impl>(&gvawatermark->info, mem_type, GST_ELEMENT(trans), gvawatermark->displ_avgfps,
+                                   gvawatermark->displ_cfg, gvawatermark->device);
     } catch (const std::exception &e) {
         GST_ELEMENT_ERROR(gvawatermark, CORE, FAILED, ("Could not initialize"),
                           ("Cannot create watermark instance. %s", Utils::createNestedErrorMsg(e).c_str()));
@@ -869,8 +869,8 @@ bool Impl::render_gpu(VADisplay display, VASurfaceID surface) {
             _renderer_gpu_unavailable = true;
             return false;
         }
-        _renderer_gpu = RendererGPU::create(display, GST_VIDEO_INFO_WIDTH(_vinfo), GST_VIDEO_INFO_HEIGHT(_vinfo),
-                                            _converter);
+        _renderer_gpu =
+            RendererGPU::create(display, GST_VIDEO_INFO_WIDTH(_vinfo), GST_VIDEO_INFO_HEIGHT(_vinfo), _converter);
         if (!_renderer_gpu) {
             GST_WARNING_OBJECT(_element, "Could not create the OpenCL watermark renderer; using the CPU renderer");
             _renderer_gpu_unavailable = true;

--- a/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
+++ b/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
@@ -39,6 +39,13 @@
 #include "renderer/color_converter.h"
 #include "renderer/cpu/create_renderer.h"
 
+// Renders primitives straight into the VA surface planes with OpenCL, with no
+// NV12<->BGR round trip. Needs both VA (for the surface) and OpenCL.
+#if defined(ENABLE_GVAWATERMARK_GPU) && defined(ENABLE_VAAPI) && !defined(_WIN32)
+#define GVA_WATERMARK_GPU_RENDERER 1
+#include "renderer/gpu/renderer_gpu.h"
+#endif
+
 #include <array>
 #include <exception>
 #include <optional>
@@ -130,11 +137,14 @@ InferenceBackend::MemoryType memoryTypeFromCaps(GstCaps *caps) {
 
 struct Impl {
     Impl(GstVideoInfo *info, InferenceBackend::MemoryType mem_type, GstElement *element, bool displ_avgfps,
-         gchar *displ_cfg);
+         gchar *displ_cfg, const gchar *device);
     bool extract_primitives(GstBuffer *buffer);
     int get_num_primitives() const;
     bool render(GstBuffer *buffer);
-    [[nodiscard]] bool render_va(cv::Mat *overlay, cv::UMat *frame);
+    /* Renders into the VA surface with OpenCL. Returns false when the path is
+     * unavailable or the frame contains a primitive it cannot draw yet; the
+     * caller must then fall back to render(). */
+    [[nodiscard]] bool render_gpu(VADisplay display, VASurfaceID surface);
     const std::string &getBackendType() const {
         return _backend_type;
     }
@@ -155,22 +165,23 @@ struct Impl {
 
     std::unique_ptr<Renderer> createRenderer(std::shared_ptr<ColorConverter> converter);
 
-    std::unique_ptr<Renderer> createGPURenderer(dlstreamer::ImageFormat format,
-                                                std::shared_ptr<ColorConverter> converter,
-                                                InferenceBackend::MemoryType mem_type,
-                                                dlstreamer::ContextPtr vaapi_context);
-
-    std::unique_ptr<Renderer> createOpenCVRenderer(std::shared_ptr<ColorConverter> converter);
-
     GstVideoInfo *_vinfo;
     GstElement *_element;
     GstElement *_gvafpscounter_element = nullptr;
     std::string _backend_type;
     InferenceBackend::MemoryType _mem_type;
 
-    SharedObject::Ptr _gpurenderer_loader;
     std::unique_ptr<Renderer> _renderer;
-    std::unique_ptr<Renderer> _renderer_opencv;
+
+    /* Kept alive for the GPU renderer, which is created lazily on the first VA
+     * frame (the VADisplay is not known when Impl is constructed). */
+    std::shared_ptr<ColorConverter> _converter;
+#ifdef GVA_WATERMARK_GPU_RENDERER
+    std::unique_ptr<RendererGPU> _renderer_gpu;
+    bool _renderer_gpu_unavailable = false; // sticky: do not retry creation per frame
+    bool _renderer_gpu_active = false;      // logging only
+    std::string _renderer_gpu_declined;     // logging only, last reported fallback reason
+#endif
 
     std::vector<render::Prim> prims;
 
@@ -383,7 +394,8 @@ static gboolean gst_gva_watermark_impl_set_caps(GstBaseTransform *trans, GstCaps
 
     try {
         gvawatermark->impl = std::make_shared<Impl>(&gvawatermark->info, mem_type, GST_ELEMENT(trans),
-                                                    gvawatermark->displ_avgfps, gvawatermark->displ_cfg);
+                                                    gvawatermark->displ_avgfps, gvawatermark->displ_cfg,
+                                                    gvawatermark->device);
     } catch (const std::exception &e) {
         GST_ELEMENT_ERROR(gvawatermark, CORE, FAILED, ("Could not initialize"),
                           ("Cannot create watermark instance. %s", Utils::createNestedErrorMsg(e).c_str()));
@@ -465,31 +477,6 @@ static void gst_gva_watermark_impl_set_context(GstElement *elem, GstContext *con
         self->vaapi_ctx = std::make_shared<dlstreamer::VAAPIContext>(self->va_dpy);
         self->gst_to_vaapi = std::make_shared<dlstreamer::MemoryMapperGSTToVAAPI>(self->gst_ctx, self->vaapi_ctx);
         GST_INFO_OBJECT(self, "Initialized VAAPI context and GST->VAAPI mapper");
-
-        static bool ocl_ctx_inited = false;
-        if (!ocl_ctx_inited && !g_getenv("VA_GPU_DISABLE_VA_OCL_INIT")) {
-            try {
-                cv::va_intel::ocl::initializeContextFromVA(self->va_dpy, /*interop*/ true);
-                GST_INFO_OBJECT(self, "OpenCV VA/OpenCL context initialized (zero-copy requested)");
-                ocl_ctx_inited = true;
-
-                if (cv::ocl::useOpenCL()) {
-                    cv::ocl::Device dev = cv::ocl::Device::getDefault();
-#if defined(CV_VERSION_MAJOR)
-                    GST_INFO_OBJECT(self, "OpenCL device: %s (vendor=%s version=%s driver=%s)", dev.name().c_str(),
-                                    dev.vendorName().c_str(), dev.version().c_str(), dev.driverVersion().c_str());
-#else
-                    GST_INFO_OBJECT(self, "OpenCL device: %s (vendorID=%d version=%s)", dev.name().c_str(),
-                                    dev.vendorID(), dev.version().c_str());
-#endif
-                } else {
-                    GST_WARNING_OBJECT(self, "OpenCL not active after initializeContextFromVA");
-                }
-            } catch (const cv::Exception &e) {
-                GST_WARNING_OBJECT(self, "initializeContextFromVA failed: %s (will use fallback copies if any)",
-                                   e.what());
-            }
-        }
     }
 #endif // ENABLE_VAAPI && !_WIN32
 
@@ -610,53 +597,14 @@ static GstFlowReturn gst_gva_watermark_impl_transform_ip(GstBaseTransform *trans
         if (use_gpu_path) {
             GST_TRACE_OBJECT(gvawatermark, "Using VA/GPU render path");
 
-            VASurfaceID sid = VA_INVALID_SURFACE;
-            sid = get_surface_from_buffer(buf);
+            VASurfaceID sid = get_surface_from_buffer(buf);
             if (sid == VA_INVALID_SURFACE) {
                 GST_WARNING_OBJECT(gvawatermark,
                                    "Mapped frame is not VAAPIFrame and GstVA fallback failed; pass-through");
                 use_gpu_path = false;
             } else {
-                GST_INFO_OBJECT(gvawatermark, "Using GstVA, VASurfaceID=%d", (int)sid);
-                // At this point you have valid VADisplay (self->va_dpy) and VASurfaceID (sid)
-                GST_LOG_OBJECT(gvawatermark, "Got VADisplay=%p, VASurfaceID=%d", gvawatermark->va_dpy, (int)sid);
-
-                const int width = GST_VIDEO_INFO_WIDTH(&gvawatermark->info);
-                const int height = GST_VIDEO_INFO_HEIGHT(&gvawatermark->info);
-
-                if (!gvawatermark->overlay_ready || gvawatermark->overlay_cpu.empty() ||
-                    gvawatermark->overlay_cpu.cols != width || gvawatermark->overlay_cpu.rows != height ||
-                    gvawatermark->overlay_cpu.type() != CV_8UC3) {
-
-                    gvawatermark->overlay_cpu.create(height, width, CV_8UC3);
-                    gvawatermark->overlay_ready = true;
-                    GST_INFO_OBJECT(gvawatermark, "Allocated CPU overlay (%dx%d CV_8UC3)", width, height);
-                }
-
-                // Clear only once per frame (fast memset on host)
-                gvawatermark->overlay_cpu.setTo(cv::Scalar(0, 0, 0, 0));
-
-                if (!cv::ocl::useOpenCL()) {
-                    GST_WARNING_OBJECT(gvawatermark, "OpenCL not available; skipping GPU render for this frame");
-                    use_gpu_path = false;
-                } else {
-                    cv::UMat u;
-                    cv::va_intel::convertFromVASurface(gvawatermark->va_dpy, sid, cv::Size(width, height), u);
-
-                    bool has_overlay = gvawatermark->impl->render_va(&(gvawatermark->overlay_cpu), &u);
-
-                    if (has_overlay) {
-                        // Upload once (host -> UMat). OpenCL runtime can keep it on device afterward.
-                        gvawatermark->overlay_cpu.copyTo(gvawatermark->overlay_gpu);
-
-                        cv::UMat gray, mask;
-                        cv::cvtColor(gvawatermark->overlay_gpu, gray, cv::COLOR_BGR2GRAY);
-                        cv::threshold(gray, mask, 0, 255, cv::THRESH_BINARY);
-                        gvawatermark->overlay_gpu.copyTo(u, mask);
-                    }
-
-                    cv::va_intel::convertToVASurface(gvawatermark->va_dpy, u, sid, cv::Size(width, height));
-                }
+                GST_TRACE_OBJECT(gvawatermark, "Got VADisplay=%p, VASurfaceID=%d", gvawatermark->va_dpy, (int)sid);
+                use_gpu_path = gvawatermark->impl->render_gpu(gvawatermark->va_dpy, sid);
             }
         }
 #endif // ENABLE_VAAPI
@@ -738,8 +686,9 @@ static void gst_gva_watermark_impl_class_init(GstGvaWatermarkImplClass *klass) {
 }
 
 Impl::Impl(GstVideoInfo *info, InferenceBackend::MemoryType mem_type, GstElement *element, bool displ_avgfps,
-           gchar *displ_cfg)
-    : _vinfo(info), _element(element), _mem_type(mem_type), _displ_avgfps(displ_avgfps), _displ_cfg(displ_cfg) {
+           gchar *displ_cfg, const gchar *device)
+    : _vinfo(info), _element(element), _backend_type(device ? device : DEFAULT_DEVICE), _mem_type(mem_type),
+      _displ_avgfps(displ_avgfps), _displ_cfg(displ_cfg) {
     assert(_vinfo);
     if (GST_VIDEO_INFO_COLORIMETRY(_vinfo).matrix == GstVideoColorMatrix::GST_VIDEO_COLOR_MATRIX_UNKNOWN)
         throw std::runtime_error("GST_VIDEO_COLOR_MATRIX_UNKNOWN");
@@ -749,12 +698,9 @@ Impl::Impl(GstVideoInfo *info, InferenceBackend::MemoryType mem_type, GstElement
     gst_video_color_matrix_get_Kr_Kb(colorimetry.matrix, &Kr, &Kb);
 
     dlstreamer::ImageFormat format = dlstreamer::gst_format_to_video_format(GST_VIDEO_INFO_FORMAT(_vinfo));
-    std::shared_ptr<ColorConverter> converter = create_color_converter(format, color_table, Kr, Kb);
-    std::shared_ptr<ColorConverter> converterBGR =
-        create_color_converter(dlstreamer::ImageFormat::BGR, color_table, Kr, Kb);
+    _converter = create_color_converter(format, color_table, Kr, Kb);
 
-    _renderer = createRenderer(std::move(converter));
-    _renderer_opencv = createOpenCVRenderer(std::move(converterBGR));
+    _renderer = createRenderer(_converter);
 
     // Find gvafpscounter element in the pipeline to put avg-fps on output video
     if (_displ_avgfps)
@@ -906,40 +852,53 @@ bool Impl::render(GstBuffer *buffer) {
     return true;
 }
 
-bool Impl::render_va(cv::Mat *overlay, cv::UMat *frame) {
+bool Impl::render_gpu(VADisplay display, VASurfaceID surface) {
     ITT_TASK(__FUNCTION__);
 
+#ifdef GVA_WATERMARK_GPU_RENDERER
     if (prims.empty())
+        return true;
+    if (_renderer_gpu_unavailable)
         return false;
 
-    // Apply blur directly on the GPU-resident UMat frame (via OpenCL T-API).
-    // Blur must happen before overlay compositing — it modifies existing pixels,
-    // which the black-overlay + binary-mask approach cannot express.
-    bool has_overlay_prims = false;
-    for (auto it = prims.begin(); it != prims.end();) {
-        if (std::holds_alternative<render::Blur>(*it)) {
-            const auto &blur = std::get<render::Blur>(*it);
-            cv::Rect r = blur.rect;
-            if (r.width <= 0 || r.height <= 0) {
-                it = prims.erase(it);
-                continue;
-            }
-            cv::Size ksize = render::computeBlurKernelSize(r.width, r.height);
-            cv::UMat roi(*frame, r);
-            cv::GaussianBlur(roi, roi, ksize, 0, 0);
-            it = prims.erase(it);
-        } else {
-            has_overlay_prims = true;
-            ++it;
+    if (!_renderer_gpu) {
+        // NV12 only; anything else keeps using the CPU renderer.
+        if (GST_VIDEO_INFO_FORMAT(_vinfo) != GST_VIDEO_FORMAT_NV12) {
+            GST_INFO_OBJECT(_element, "OpenCL watermark renderer has no path for %s; using the CPU renderer",
+                            gst_video_format_to_string(GST_VIDEO_INFO_FORMAT(_vinfo)));
+            _renderer_gpu_unavailable = true;
+            return false;
+        }
+        _renderer_gpu = RendererGPU::create(display, GST_VIDEO_INFO_WIDTH(_vinfo), GST_VIDEO_INFO_HEIGHT(_vinfo),
+                                            _converter);
+        if (!_renderer_gpu) {
+            GST_WARNING_OBJECT(_element, "Could not create the OpenCL watermark renderer; using the CPU renderer");
+            _renderer_gpu_unavailable = true;
+            return false;
         }
     }
 
-    // Render remaining (non-blur) primitives onto the CPU overlay
-    if (has_overlay_prims) {
-        _renderer_opencv->draw_va(*overlay, prims);
+    if (_renderer_gpu->draw_surface(surface, prims)) {
+        if (!_renderer_gpu_active) {
+            _renderer_gpu_active = true;
+            GST_INFO_OBJECT(_element, "OpenCL watermark renderer active");
+        }
+        return true;
     }
 
-    return has_overlay_prims;
+    // Only report each distinct reason once: the fallback is per frame, and the
+    // primitive mix is usually the same on every frame.
+    if (_renderer_gpu_declined != _renderer_gpu->last_unsupported()) {
+        _renderer_gpu_declined = _renderer_gpu->last_unsupported();
+        GST_INFO_OBJECT(_element, "OpenCL watermark renderer declined the frame (%s); using the CPU renderer",
+                        _renderer_gpu_declined.c_str());
+    }
+    return false;
+#else
+    UNUSED(display);
+    UNUSED(surface);
+    return false;
+#endif
 }
 
 inline bool Impl::is_ROI_filtered_out(const std::string &label) const {
@@ -1326,13 +1285,6 @@ std::unique_ptr<Renderer> Impl::createRenderer(std::shared_ptr<ColorConverter> c
 
     dlstreamer::ImageFormat format = dlstreamer::gst_format_to_video_format(GST_VIDEO_INFO_FORMAT(_vinfo));
     auto buf_mapper = BufferMapperFactory::createMapper(InferenceBackend::MemoryType::SYSTEM);
-    return create_cpu_renderer(format, converter, std::move(buf_mapper));
-}
-
-std::unique_ptr<Renderer> Impl::createOpenCVRenderer(std::shared_ptr<ColorConverter> converter) {
-
-    auto buf_mapper = BufferMapperFactory::createMapper(InferenceBackend::MemoryType::SYSTEM);
-    auto format = dlstreamer::ImageFormat::BGR;
     return create_cpu_renderer(format, converter, std::move(buf_mapper));
 }
 

--- a/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
+++ b/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
@@ -687,7 +687,10 @@ static void gst_gva_watermark_impl_class_init(GstGvaWatermarkImplClass *klass) {
 
 Impl::Impl(GstVideoInfo *info, InferenceBackend::MemoryType mem_type, GstElement *element, bool displ_avgfps,
            gchar *displ_cfg, const gchar *device)
-    : _vinfo(info), _element(element), _backend_type(device ? device : DEFAULT_DEVICE), _mem_type(mem_type),
+    // The "device" property defaults to NULL on this element, which set_caps reads as
+    // "pick the renderer from the memory type". DEFAULT_DEVICE is that NULL, so it must
+    // not reach the std::string here.
+    : _vinfo(info), _element(element), _backend_type(device ? device : ""), _mem_type(mem_type),
       _displ_avgfps(displ_avgfps), _displ_cfg(displ_cfg) {
     assert(_vinfo);
     if (GST_VIDEO_INFO_COLORIMETRY(_vinfo).matrix == GstVideoColorMatrix::GST_VIDEO_COLOR_MATRIX_UNKNOWN)

--- a/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.h
+++ b/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.h
@@ -86,7 +86,6 @@ enum { PROP_0, PROP_DEVICE, PROP_OBB, PROP_DISPL_AVGFPS, PROP_DISPL_CFG };
     "\t\t\tshow-blur-roi=<string> colon-separated list of object labels to blur (e.g. 'face:person')\n"                \
     "\t\t\thide-blur-roi=<string> colon-separated list of object labels to exclude from blurring\n"                    \
     "\t\t\tNOTE: show-blur-roi takes precedence over hide-blur-roi when both are specified\n"                          \
-    "\t\t\tNOTE: currently this option is only supported for CPU\n"                                                    \
     "\t\t\ttext-x=<float> x position (pixels) for full-frame text (e.g. from gvagenai), default 0\n"                   \
     "\t\t\ttext-y=<float> y position (pixels) for full-frame text (e.g. from gvagenai), default 25\n"                  \
     "\t\t\tff-custom-txt=<string> extra custom text for full-frame display (limit 20 characters), "                    \

--- a/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.h
+++ b/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.h
@@ -15,11 +15,9 @@
 #ifndef _WIN32
 #include <dlstreamer/gst/context.h>
 #include <dlstreamer/vaapi/context.h>
-#include <opencv2/core/va_intel.hpp>
 #endif
 
 #include <opencv2/core.hpp>
-#include <opencv2/core/ocl.hpp>
 #include <opencv2/imgproc.hpp>
 
 G_BEGIN_DECLS
@@ -51,10 +49,6 @@ struct _GstGvaWatermarkImpl {
     std::shared_ptr<dlstreamer::VAAPIContext> vaapi_ctx;
     std::shared_ptr<dlstreamer::MemoryMapperGSTToVAAPI> gst_to_vaapi;
 #endif
-
-    bool overlay_ready = false;
-    cv::Mat overlay_cpu;
-    cv::UMat overlay_gpu;
 };
 
 struct _GstGvaWatermarkImplClass {

--- a/src/monolithic/gst/elements/gvawatermark/renderer/gpu/renderer_gpu.cpp
+++ b/src/monolithic/gst/elements/gvawatermark/renderer/gpu/renderer_gpu.cpp
@@ -206,8 +206,8 @@ bool RendererGPU::SharedContext::build(VADisplay display) {
      * to the CPU renderer if the extension is missing. */
     for (cl_platform_id platform : platforms) {
         auto ext = [platform](const char *name) { return clGetExtensionFunctionAddressForPlatform(platform, name); };
-        auto get_devices =
-            reinterpret_cast<clGetDeviceIDsFromVA_APIMediaAdapterINTEL_fn>(ext("clGetDeviceIDsFromVA_APIMediaAdapterINTEL"));
+        auto get_devices = reinterpret_cast<clGetDeviceIDsFromVA_APIMediaAdapterINTEL_fn>(
+            ext("clGetDeviceIDsFromVA_APIMediaAdapterINTEL"));
         auto create_surface =
             reinterpret_cast<clCreateFromVA_APIMediaSurfaceINTEL_fn>(ext("clCreateFromVA_APIMediaSurfaceINTEL"));
         auto acquire_fn = reinterpret_cast<clEnqueueAcquireVA_APIMediaSurfacesINTEL_fn>(
@@ -228,10 +228,8 @@ bool RendererGPU::SharedContext::build(VADisplay display) {
          * on the driver, so the acquire/release pair around the kernels is all
          * the sync we need; no explicit vaSyncSurface. */
         cl_context_properties props[] = {CL_CONTEXT_VA_API_DISPLAY_INTEL,
-                                         reinterpret_cast<cl_context_properties>(display),
-                                         CL_CONTEXT_INTEROP_USER_SYNC,
-                                         CL_FALSE,
-                                         0};
+                                         reinterpret_cast<cl_context_properties>(display), CL_CONTEXT_INTEROP_USER_SYNC,
+                                         CL_FALSE, 0};
         cl_context ctx = clCreateContext(props, 1, &dev, nullptr, nullptr, &err);
         if (!ctx || err != CL_SUCCESS) {
             cl_ok(err, "clCreateContext");
@@ -764,7 +762,8 @@ void RendererGPU::insert_span(std::vector<SpanRec> &row, int a, int b, const cl_
             ++i;
             continue;
         }
-        const bool left = x1 < a, right = x2 > b;
+        const bool left = (x1 < a);
+        const bool right = (x2 > b);
         if (left && right) {
             /* The old entry is split in two. Taking a copy of the colour first
              * matters: push_back may reallocate and invalidate row[i]. */
@@ -807,9 +806,8 @@ bool RendererGPU::add_raster(BatchId span_id, const renderer_gpu::Raster &raster
     for (const cv::Point &pt : raster.points)
         _merge.push_back({pt.y, pt.x, pt.x});
 
-    std::sort(_merge.begin(), _merge.end(), [](const Span &a, const Span &b) {
-        return a.y != b.y ? a.y < b.y : a.x1 < b.x1;
-    });
+    std::sort(_merge.begin(), _merge.end(),
+              [](const Span &a, const Span &b) { return a.y != b.y ? a.y < b.y : a.x1 < b.x1; });
 
     /* Runs go into the per-row lists rather than straight into a group, because
      * work items of one NDRange are unordered: two records covering the same
@@ -1090,15 +1088,13 @@ bool RendererGPU::flatten_blur(const render::Blur &blur) {
         /* sepFilter2D takes the integer fixed-point path only when *both*
          * kernels quantize exactly, so the decision is per blur, not per
          * kernel. In practice that means the small kernels of a small ROI. */
-        add_blur(job.id, job.rect, job.cn, job.ksize.width, job.ksize.height, *cx, *cy,
-                 cx->int_valid && cy->int_valid);
+        add_blur(job.id, job.rect, job.cn, job.ksize.width, job.ksize.height, *cx, *cy, cx->int_valid && cy->int_valid);
     }
     return true;
 }
 
 bool RendererGPU::flatten_instance_mask(const render::InstanceSegmantationMask &mask) {
-    if (mask.size.width <= 0 || mask.size.height <= 0 ||
-        mask.data.size() != static_cast<size_t>(mask.size.area())) {
+    if (mask.size.width <= 0 || mask.size.height <= 0 || mask.data.size() != static_cast<size_t>(mask.size.area())) {
         _last_unsupported = "malformed instance segmentation mask";
         return false;
     }
@@ -1140,9 +1136,9 @@ bool RendererGPU::flatten_instance_mask(const render::InstanceSegmantationMask &
         if (roi_uv.width > 0 && roi_uv.height > 0) {
             cv::resize(raw_cls_mask, resized_uv, {half_coord(w) + 1, half_coord(h) + 1});
             const int bx_uv = half_coord(box.x), by_uv = half_coord(box.y);
-            cv::threshold(resized_uv({cv::Point(x0_uv - bx_uv, y0_uv - by_uv),
-                                      cv::Point(x1_uv - bx_uv, y1_uv - by_uv)}),
-                          binary_uv, 0.5f, 1.0f, cv::THRESH_BINARY);
+            cv::threshold(
+                resized_uv({cv::Point(x0_uv - bx_uv, y0_uv - by_uv), cv::Point(x1_uv - bx_uv, y1_uv - by_uv)}),
+                binary_uv, 0.5f, 1.0f, cv::THRESH_BINARY);
             binary_uv.convertTo(binary_uv, CV_8U);
         }
     } catch (const cv::Exception &e) {
@@ -1444,8 +1440,8 @@ bool RendererGPU::get_planes(VASurfaceID surface, cl_mem planes[2]) {
      * frames and then never again. A count that keeps climbing over a long run
      * means surfaces are not being recycled and the imports are a leak, which
      * is otherwise only visible as GPU memory growth. */
-    GST_DEBUG("gvawatermark GPU renderer: imported surface %u, %zu in the plane cache",
-              static_cast<unsigned>(surface), _plane_cache.size());
+    GST_DEBUG("gvawatermark GPU renderer: imported surface %u, %zu in the plane cache", static_cast<unsigned>(surface),
+              _plane_cache.size());
     return true;
 }
 
@@ -1467,8 +1463,7 @@ bool RendererGPU::enqueue(const Group &group, cl_mem image, int image_w, int ima
                                 static_cast<size_t>(p.a.s[3])};
         cl_mem side = is_blur ? _coeff_buffer : _blob_buffer;
         if (!side) {
-            GST_WARNING("gvawatermark GPU renderer: %s dispatch without its data buffer",
-                        is_blur ? "blur" : "blend");
+            GST_WARNING("gvawatermark GPU renderer: %s dispatch without its data buffer", is_blur ? "blur" : "blend");
             return false;
         }
 
@@ -1587,8 +1582,7 @@ bool RendererGPU::draw_surface(VASurfaceID surface, std::vector<render::Prim> pr
 
     /* Release makes the writes visible to VA; the following finish makes them
      * visible to the downstream element. */
-    cl_ok(_shared->release(_queue, n_planes, planes, 0, nullptr, nullptr),
-          "clEnqueueReleaseVA_APIMediaSurfacesINTEL");
+    cl_ok(_shared->release(_queue, n_planes, planes, 0, nullptr, nullptr), "clEnqueueReleaseVA_APIMediaSurfacesINTEL");
     if (!cl_ok(clFinish(_queue), "clFinish"))
         return false;
 

--- a/src/monolithic/gst/elements/gvawatermark/renderer/gpu/renderer_gpu.cpp
+++ b/src/monolithic/gst/elements/gvawatermark/renderer/gpu/renderer_gpu.cpp
@@ -1,0 +1,1593 @@
+/*******************************************************************************
+ * Copyright (C) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifdef ENABLE_GVAWATERMARK_GPU
+
+#include "renderer_gpu.h"
+#include "renderer_gpu_kernels.h"
+
+#include <gst/gst.h>
+#include <gst/video/video.h>
+#include <opencv2/opencv.hpp>
+
+#include <algorithm>
+#include <cfloat>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <mutex>
+
+GST_DEBUG_CATEGORY_STATIC(gva_watermark_gpu_debug);
+#define GST_CAT_DEFAULT gva_watermark_gpu_debug
+
+namespace {
+
+constexpr size_t ATLAS_MAX_BYTES = 4u << 20;
+constexpr size_t ATLAS_MAX_ENTRIES = 1024;
+
+/* Runs and single pixels are cheap individually but a dense segmentation
+ * contour can emit a great many of them. Past this budget the frame goes to the
+ * CPU renderer rather than growing the upload without bound; at 48 bytes a
+ * record this caps the per-frame transfer at 48 MB. */
+constexpr size_t RASTER_MAX_RECORDS = 1u << 20;
+
+/* Segmentation coverage bitmaps are rebuilt every frame, so this only has to
+ * bound one frame's worth: 64 MB is far past anything a detector emits. */
+constexpr size_t BLOB_MAX_BYTES = 64u << 20;
+
+/* Gaussian kernel lengths follow the ROI sizes, so a stream settles on a few of
+ * them. The cap is only there to stop an adversarial stream of ever-changing
+ * ROI sizes from growing the table without bound. */
+constexpr size_t COEFF_MAX_ENTRIES = 256;
+
+/* RendererYUV halves the line thickness on the U and V planes, and also uses
+ * the halved thickness on the Y plane (drawing twice with a parity offset) so
+ * the half-resolution chroma does not leave a shadow. Same rule as
+ * calc_thick_for_u_v_planes() in renderer_cpu.cpp. */
+int half_thickness(int thick) {
+    if (thick <= 1)
+        return thick;
+    return thick / 2;
+}
+
+/* cv::rectangle(LINE_8, thickness) draws each edge as a band centred on the
+ * edge and extending +-k pixels across it; measured against OpenCV for
+ * thickness 1..8. Thickness 1 takes OpenCV's thin-line path, a single pixel. */
+int band_half_width(int thick) {
+    if (thick <= 1)
+        return 0;
+    return (thick + 1) / 2;
+}
+
+/* calc_point_for_u_v_planes(): cv::Point / 2, i.e. integer division that
+ * truncates towards zero. Replicated verbatim so the GPU lands on the same
+ * chroma pixel as the CPU renderer. */
+int half_coord(int v) {
+    return v / 2;
+}
+
+/* Plane colours come from the same conversion for a given render::Prim colour,
+ * so exact float equality is the right test here: it answers "would these two
+ * work items write the same byte", not "are these colours close". */
+bool same_color(const cl_float4 &a, const cl_float4 &b) {
+    return a.s[0] == b.s[0] && a.s[1] == b.s[1] && a.s[2] == b.s[2] && a.s[3] == b.s[3];
+}
+
+/* clamp() and expand_box() from renderer_cpu.cpp, which draw_instance_mask uses
+ * to place the resampled mask. Copied rather than shared so the two renderers
+ * cannot drift apart silently. */
+template <typename T>
+T clamp_to(T value, T low, T high) {
+    return value < low ? low : (value > high ? high : value);
+}
+
+cv::Rect expand_box(const cv::Rect2f &box, float w_scale, float h_scale) {
+    float w_half = box.width * 0.5f * w_scale, h_half = box.height * 0.5f * h_scale;
+    const cv::Point2f &center = (box.tl() + box.br()) * 0.5f;
+    return {cv::Point(int(center.x - w_half), int(center.y - h_half)),
+            cv::Point(int(center.x + w_half), int(center.y + h_half))};
+}
+
+/* cv::getKernelType() restricted to the question createSeparableLinearFilter
+ * actually asks of a smoothing kernel: is it exactly
+ * KERNEL_SMOOTH + KERNEL_SYMMETRICAL, which is the gate on the integer
+ * fixed-point path. A Gaussian normally is; a degenerate one-tap kernel is not,
+ * because it is also KERNEL_INTEGER. */
+bool is_smooth_symmetrical(const cv::Mat &kernel) {
+    const int n = kernel.rows * kernel.cols;
+    double sum = 0;
+    bool all_integer = true;
+    for (int i = 0; i < n; ++i) {
+        const double a = kernel.at<float>(i), b = kernel.at<float>(n - i - 1);
+        if (a != b || a < 0)
+            return false;
+        if (a != static_cast<double>(cv::saturate_cast<int>(a)))
+            all_integer = false;
+        sum += a;
+    }
+    if (all_integer)
+        return false; // KERNEL_INTEGER would survive too, and the gate is ==
+    return std::fabs(sum - 1) <= FLT_EPSILON * (std::fabs(sum) + 1);
+}
+
+/* createBitExactKernel_32S(kernel, ., 8): can every coefficient be replaced by
+ * round(c * 256) without moving it more than the tolerance OpenCV allows? */
+bool bit_exact_256(const cv::Mat &kernel, std::vector<float> &scaled) {
+    const int n = kernel.rows * kernel.cols;
+    const double eps = 10 * FLT_EPSILON * 256;
+    scaled.resize(n);
+    for (int i = 0; i < n; ++i) {
+        const double approx = static_cast<double>(kernel.at<float>(i)) * 256;
+        const int exact = cv::saturate_cast<int>(approx);
+        if (std::fabs(approx - exact) > eps)
+            return false;
+        scaled[i] = static_cast<float>(exact);
+    }
+    return true;
+}
+
+bool cl_ok(cl_int err, const char *what) {
+    if (err == CL_SUCCESS)
+        return true;
+    GST_WARNING("gvawatermark GPU renderer: %s failed with OpenCL error %d", what, static_cast<int>(err));
+    return false;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// SharedContext
+// ---------------------------------------------------------------------------
+
+struct RendererGPU::SharedContext {
+    cl_platform_id platform = nullptr;
+    cl_device_id device = nullptr;
+    cl_context context = nullptr;
+    cl_program program = nullptr;
+
+    clCreateFromVA_APIMediaSurfaceINTEL_fn create_from_va = nullptr;
+    clEnqueueAcquireVA_APIMediaSurfacesINTEL_fn acquire = nullptr;
+    clEnqueueReleaseVA_APIMediaSurfacesINTEL_fn release = nullptr;
+
+    ~SharedContext() {
+        if (program)
+            clReleaseProgram(program);
+        if (context)
+            clReleaseContext(context);
+    }
+
+    static std::shared_ptr<SharedContext> get(VADisplay display);
+
+  private:
+    bool build(VADisplay display);
+    bool build_program();
+};
+
+bool RendererGPU::SharedContext::build_program() {
+    cl_int err = CL_SUCCESS;
+    const char *source = renderer_gpu::KERNELS;
+    cl_program prog = clCreateProgramWithSource(context, 1, &source, nullptr, &err);
+    if (!prog || err != CL_SUCCESS) {
+        cl_ok(err, "clCreateProgramWithSource");
+        return false;
+    }
+
+    err = clBuildProgram(prog, 1, &device, "-cl-fast-relaxed-math", nullptr, nullptr);
+    if (err != CL_SUCCESS) {
+        size_t log_size = 0;
+        clGetProgramBuildInfo(prog, device, CL_PROGRAM_BUILD_LOG, 0, nullptr, &log_size);
+        std::string log(log_size, '\0');
+        clGetProgramBuildInfo(prog, device, CL_PROGRAM_BUILD_LOG, log_size, log.data(), nullptr);
+        GST_ERROR("gvawatermark GPU renderer: kernel build failed (%d): %s", static_cast<int>(err), log.c_str());
+        clReleaseProgram(prog);
+        return false;
+    }
+
+    program = prog;
+    return true;
+}
+
+bool RendererGPU::SharedContext::build(VADisplay display) {
+    cl_uint num_platforms = 0;
+    if (!cl_ok(clGetPlatformIDs(0, nullptr, &num_platforms), "clGetPlatformIDs") || num_platforms == 0)
+        return false;
+    std::vector<cl_platform_id> platforms(num_platforms);
+    if (!cl_ok(clGetPlatformIDs(num_platforms, platforms.data(), nullptr), "clGetPlatformIDs"))
+        return false;
+
+    /* cl_intel_va_api_media_sharing is the only usable route to a VA surface:
+     * importing the surface's dma-buf as a flat OpenCL buffer gives a linear
+     * byte view, which addresses the wrong pixels on the Tile4 surfaces that
+     * the decoder and VPP produce. Probe once here and let the caller fall back
+     * to the CPU renderer if the extension is missing. */
+    for (cl_platform_id platform : platforms) {
+        auto ext = [platform](const char *name) { return clGetExtensionFunctionAddressForPlatform(platform, name); };
+        auto get_devices =
+            reinterpret_cast<clGetDeviceIDsFromVA_APIMediaAdapterINTEL_fn>(ext("clGetDeviceIDsFromVA_APIMediaAdapterINTEL"));
+        auto create_surface =
+            reinterpret_cast<clCreateFromVA_APIMediaSurfaceINTEL_fn>(ext("clCreateFromVA_APIMediaSurfaceINTEL"));
+        auto acquire_fn = reinterpret_cast<clEnqueueAcquireVA_APIMediaSurfacesINTEL_fn>(
+            ext("clEnqueueAcquireVA_APIMediaSurfacesINTEL"));
+        auto release_fn = reinterpret_cast<clEnqueueReleaseVA_APIMediaSurfacesINTEL_fn>(
+            ext("clEnqueueReleaseVA_APIMediaSurfacesINTEL"));
+        if (!get_devices || !create_surface || !acquire_fn || !release_fn)
+            continue;
+
+        cl_device_id dev = nullptr;
+        cl_uint num_devices = 0;
+        cl_int err = get_devices(platform, CL_VA_API_DISPLAY_INTEL, display, CL_PREFERRED_DEVICES_FOR_VA_API_INTEL, 1,
+                                 &dev, &num_devices);
+        if (err != CL_SUCCESS || num_devices == 0 || !dev)
+            continue;
+
+        /* CL_CONTEXT_INTEROP_USER_SYNC = CL_FALSE puts VA<->CL synchronization
+         * on the driver, so the acquire/release pair around the kernels is all
+         * the sync we need; no explicit vaSyncSurface. */
+        cl_context_properties props[] = {CL_CONTEXT_VA_API_DISPLAY_INTEL,
+                                         reinterpret_cast<cl_context_properties>(display),
+                                         CL_CONTEXT_INTEROP_USER_SYNC,
+                                         CL_FALSE,
+                                         0};
+        cl_context ctx = clCreateContext(props, 1, &dev, nullptr, nullptr, &err);
+        if (!ctx || err != CL_SUCCESS) {
+            cl_ok(err, "clCreateContext");
+            continue;
+        }
+
+        this->platform = platform;
+        this->device = dev;
+        this->context = ctx;
+        this->create_from_va = create_surface;
+        this->acquire = acquire_fn;
+        this->release = release_fn;
+
+        /* Build right here rather than on the first frame: a source that does
+         * not compile is a property of this platform, and the caller wants to
+         * know now, while it can still pick the CPU renderer. */
+        if (!build_program()) {
+            this->platform = nullptr;
+            this->device = nullptr;
+            this->context = nullptr;
+            clReleaseContext(ctx);
+            continue;
+        }
+
+        char name[256] = {};
+        clGetDeviceInfo(dev, CL_DEVICE_NAME, sizeof(name) - 1, name, nullptr);
+        GST_INFO("gvawatermark GPU renderer: OpenCL device '%s' bound to VADisplay %p", name, display);
+        return true;
+    }
+
+    GST_WARNING("gvawatermark GPU renderer: no OpenCL platform exposes cl_intel_va_api_media_sharing for "
+                "VADisplay %p; falling back to the CPU renderer",
+                display);
+    return false;
+}
+
+std::shared_ptr<RendererGPU::SharedContext> RendererGPU::SharedContext::get(VADisplay display) {
+    static std::mutex mutex;
+    static std::map<VADisplay, std::weak_ptr<SharedContext>> cache;
+    static std::map<VADisplay, bool> failed;
+
+    std::lock_guard<std::mutex> lock(mutex);
+    if (auto it = cache.find(display); it != cache.end()) {
+        if (auto shared = it->second.lock())
+            return shared;
+    }
+    if (failed.count(display))
+        return nullptr;
+
+    auto shared = std::shared_ptr<SharedContext>(new SharedContext());
+    if (!shared->build(display)) {
+        failed[display] = true;
+        return nullptr;
+    }
+    cache[display] = shared;
+    return shared;
+}
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+RendererGPU::RendererGPU(std::shared_ptr<SharedContext> shared, std::shared_ptr<ColorConverter> color_converter,
+                         int width, int height)
+    : _shared(std::move(shared)), _color_converter(std::move(color_converter)), _width(width), _height(height) {
+}
+
+std::unique_ptr<RendererGPU> RendererGPU::create(VADisplay display, int width, int height,
+                                                 std::shared_ptr<ColorConverter> color_converter) {
+    static std::once_flag category_once;
+    std::call_once(category_once, [] {
+        GST_DEBUG_CATEGORY_INIT(gva_watermark_gpu_debug, "gvawatermarkgpu", 0,
+                                "gvawatermark OpenCL plane-native renderer");
+    });
+
+    if (!display || width <= 1 || height <= 1 || !color_converter)
+        return nullptr;
+
+    auto shared = SharedContext::get(display);
+    if (!shared)
+        return nullptr;
+
+    auto renderer =
+        std::unique_ptr<RendererGPU>(new RendererGPU(std::move(shared), std::move(color_converter), width, height));
+    if (!renderer->init())
+        return nullptr;
+    return renderer;
+}
+
+bool RendererGPU::init() {
+    cl_program program = _shared->program;
+    cl_int err = CL_SUCCESS;
+    _queue = clCreateCommandQueueWithProperties(_shared->context, _shared->device, nullptr, &err);
+    if (!_queue || !cl_ok(err, "clCreateCommandQueueWithProperties"))
+        return false;
+
+    _k_outlines = clCreateKernel(program, "wm_outlines", &err);
+    if (!cl_ok(err, "clCreateKernel(wm_outlines)"))
+        return false;
+    _k_fills = clCreateKernel(program, "wm_fills", &err);
+    if (!cl_ok(err, "clCreateKernel(wm_fills)"))
+        return false;
+    _k_masks = clCreateKernel(program, "wm_masks", &err);
+    if (!cl_ok(err, "clCreateKernel(wm_masks)"))
+        return false;
+    _k_spans = clCreateKernel(program, "wm_spans", &err);
+    if (!cl_ok(err, "clCreateKernel(wm_spans)"))
+        return false;
+    _k_blur_h = clCreateKernel(program, "wm_blur_h", &err);
+    if (!cl_ok(err, "clCreateKernel(wm_blur_h)"))
+        return false;
+    _k_blur_v = clCreateKernel(program, "wm_blur_v", &err);
+    if (!cl_ok(err, "clCreateKernel(wm_blur_v)"))
+        return false;
+    _k_blend_gather = clCreateKernel(program, "wm_blend_gather", &err);
+    if (!cl_ok(err, "clCreateKernel(wm_blend_gather)"))
+        return false;
+    _k_blend_scatter = clCreateKernel(program, "wm_blend_scatter", &err);
+    if (!cl_ok(err, "clCreateKernel(wm_blend_scatter)"))
+        return false;
+
+    for (int plane = 0; plane < 2; ++plane)
+        _span_rows[plane].resize(plane_height(plane));
+    calibrate_blur_rounding();
+    return true;
+}
+
+RendererGPU::~RendererGPU() {
+    for (auto &entry : _plane_cache) {
+        for (cl_mem plane : entry.second) {
+            if (plane)
+                clReleaseMemObject(plane);
+        }
+    }
+    _plane_cache.clear();
+
+    if (_prim_buffer)
+        clReleaseMemObject(_prim_buffer);
+    if (_atlas_buffer)
+        clReleaseMemObject(_atlas_buffer);
+    if (_coeff_buffer)
+        clReleaseMemObject(_coeff_buffer);
+    if (_blob_buffer)
+        clReleaseMemObject(_blob_buffer);
+    if (_scratch_buffer)
+        clReleaseMemObject(_scratch_buffer);
+    if (_k_outlines)
+        clReleaseKernel(_k_outlines);
+    if (_k_fills)
+        clReleaseKernel(_k_fills);
+    if (_k_masks)
+        clReleaseKernel(_k_masks);
+    if (_k_spans)
+        clReleaseKernel(_k_spans);
+    if (_k_blur_h)
+        clReleaseKernel(_k_blur_h);
+    if (_k_blur_v)
+        clReleaseKernel(_k_blur_v);
+    if (_k_blend_gather)
+        clReleaseKernel(_k_blend_gather);
+    if (_k_blend_scatter)
+        clReleaseKernel(_k_blend_scatter);
+    if (_queue)
+        clReleaseCommandQueue(_queue);
+}
+
+// ---------------------------------------------------------------------------
+// Colours
+// ---------------------------------------------------------------------------
+
+cl_float4 RendererGPU::plane_color_y(const cv::Scalar &yuv) {
+    cl_float4 c;
+    c.s[0] = static_cast<float>(yuv[0]) / 255.f;
+    c.s[1] = c.s[2] = c.s[3] = 0.f;
+    return c;
+}
+
+cl_float4 RendererGPU::plane_color_uv(const cv::Scalar &yuv) {
+    cl_float4 c;
+    c.s[0] = static_cast<float>(yuv[1]) / 255.f;
+    c.s[1] = static_cast<float>(yuv[2]) / 255.f;
+    c.s[2] = c.s[3] = 0.f;
+    return c;
+}
+
+// ---------------------------------------------------------------------------
+// Flattening
+// ---------------------------------------------------------------------------
+
+RendererGPU::Group &RendererGPU::group_for(BatchId id, int x0, int y0, int x1, int y1, const cl_float4 &color,
+                                           bool any_color) {
+    const int plane = id & 1;
+    std::vector<Group> &groups = _groups[plane];
+    const size_t used = _group_count[plane];
+
+    /* Scanned back to front for the last group this primitive must not race
+     * with. Everything in the groups before that one is then covered too, so the
+     * scan can stop at the first hit. */
+    size_t after = 0;
+    for (size_t i = used; i-- > 0;) {
+        const Group &group = groups[i];
+        bool conflict = false;
+        for (const Group::Box &box : group.boxes) {
+            if (x1 < box.x0 || x0 > box.x1 || y1 < box.y0 || y0 > box.y1)
+                continue;
+            /* Same colour means both work items write the same value, so letting
+             * them race is harmless and does not need a group boundary. */
+            if (!any_color && !box.any_color && same_color(box.color, color))
+                continue;
+            conflict = true;
+            break;
+        }
+        if (conflict) {
+            after = i + 1;
+            break;
+        }
+    }
+
+    /* Any group at or after that point running the right kernel will do - it
+     * cannot itself hold a conflict, or the scan above would have stopped
+     * there. Reusing one keeps the dispatch count at the length of the longest
+     * overlap chain instead of the primitive count. */
+    size_t target = used;
+    for (size_t i = after; i < used; ++i) {
+        if (groups[i].id == id && !groups[i].exclusive) {
+            target = i;
+            break;
+        }
+    }
+    if (target == used) {
+        if (groups.size() <= used)
+            groups.emplace_back();
+        Group &fresh = groups[used];
+        fresh.id = id;
+        fresh.prims.clear();
+        fresh.boxes.clear();
+        fresh.max_w = 0;
+        fresh.max_h = 0;
+        fresh.base = 0;
+        fresh.exclusive = false;
+        _group_count[plane] = used + 1;
+    }
+
+    Group &group = groups[target];
+    group.boxes.push_back({x0, y0, x1, y1, color, any_color});
+    return group;
+}
+
+RendererGPU::Group &RendererGPU::exclusive_group(BatchId id, int x0, int y0, int x1, int y1) {
+    const int plane = id & 1;
+    std::vector<Group> &groups = _groups[plane];
+    const size_t used = _group_count[plane];
+    if (groups.size() <= used)
+        groups.emplace_back();
+
+    /* Appended unconditionally, which orders it after every primitive of this
+     * plane so far - a read-modify-write has to see all of them. Its box is
+     * registered any_color, so whatever comes next is in turn ordered after it. */
+    Group &group = groups[used];
+    group.id = id;
+    group.prims.clear();
+    group.boxes.clear();
+    group.max_w = 0;
+    group.max_h = 0;
+    group.base = 0;
+    group.exclusive = true;
+    _group_count[plane] = used + 1;
+
+    cl_float4 unused{};
+    group.boxes.push_back({x0, y0, x1, y1, unused, true});
+    return group;
+}
+
+void RendererGPU::add_outline(BatchId id, int x0, int y0, int x1, int y1, int k, const cl_float4 &color) {
+    if (x1 < x0)
+        std::swap(x0, x1);
+    if (y1 < y0)
+        std::swap(y0, y1);
+
+    /* The bands and the corner discs reach k pixels outside the rectangle. The
+     * box is the outline's hull rather than just the painted ring, so two nested
+     * rectangles are reported as conflicting even though they need not be; that
+     * costs one dispatch, never correctness. */
+    flush_spans_overlapping(id & 1, x0 - k, y0 - k, x1 + k, y1 + k);
+    Group &group = group_for(id, x0 - k, y0 - k, x1 + k, y1 + k, color, false);
+    Prim p{};
+    p.a.s[0] = x0;
+    p.a.s[1] = y0;
+    p.a.s[2] = x1;
+    p.a.s[3] = y1;
+    p.b.s[0] = k;
+    p.color = color;
+    group.prims.push_back(p);
+
+    // dim0 walks the longest edge, but also the 2k+1 columns of a corner disc;
+    // dim1 walks the 2k+1 rows shared by the bands and the discs.
+    group.max_w = std::max(group.max_w, std::max(std::max(x1 - x0, y1 - y0) + 1, 2 * k + 1));
+    group.max_h = std::max(group.max_h, 2 * k + 1);
+}
+
+void RendererGPU::add_fill(BatchId id, int x0, int y0, int x1, int y1, const cl_float4 &color) {
+    if (x1 < x0)
+        std::swap(x0, x1);
+    if (y1 < y0)
+        std::swap(y0, y1);
+
+    flush_spans_overlapping(id & 1, x0, y0, x1, y1);
+    Group &group = group_for(id, x0, y0, x1, y1, color, false);
+    Prim p{};
+    p.a.s[0] = x0;
+    p.a.s[1] = y0;
+    p.a.s[2] = x1;
+    p.a.s[3] = y1;
+    p.color = color;
+    group.prims.push_back(p);
+
+    group.max_w = std::max(group.max_w, x1 - x0 + 1);
+    group.max_h = std::max(group.max_h, y1 - y0 + 1);
+}
+
+void RendererGPU::add_mask(BatchId id, const AtlasEntry &entry, int dst_x, int dst_y, const cl_float4 &color) {
+    if (entry.width <= 0 || entry.height <= 0)
+        return;
+
+    /* A glyph bitmap only covers part of its box, so two overlapping labels may
+     * be split into separate groups without actually sharing a pixel. That costs
+     * one extra dispatch, never correctness. */
+    const int x1 = dst_x + entry.width - 1, y1 = dst_y + entry.height - 1;
+    flush_spans_overlapping(id & 1, dst_x, dst_y, x1, y1);
+    Group &group = group_for(id, dst_x, dst_y, x1, y1, color, false);
+    Prim p{};
+    p.a.s[0] = dst_x;
+    p.a.s[1] = dst_y;
+    p.a.s[2] = entry.width;
+    p.a.s[3] = entry.height;
+    p.b.s[0] = static_cast<cl_int>(entry.offset);
+    p.b.s[1] = entry.width; // atlas rows are packed, stride == width
+    p.color = color;
+    group.prims.push_back(p);
+
+    group.max_w = std::max(group.max_w, entry.width);
+    group.max_h = std::max(group.max_h, entry.height);
+}
+
+const RendererGPU::CoeffEntry *RendererGPU::gaussian_coeffs(int ksize) {
+    if (auto it = _coeff_index.find(ksize); it != _coeff_index.end())
+        return &it->second;
+    if (_coeff_index.size() >= COEFF_MAX_ENTRIES) {
+        _coeff_index.clear();
+        _coeff_host.clear();
+        _coeff_uploaded = 0;
+    }
+
+    /* Exactly what createGaussianKernels() does for a CV_8U image with
+     * sigma = 0: getGaussianKernel derives sigma from the length itself. */
+    cv::Mat kernel;
+    try {
+        kernel = cv::getGaussianKernel(ksize, 0, CV_32F);
+    } catch (const cv::Exception &e) {
+        GST_WARNING("gvawatermark GPU renderer: getGaussianKernel(%d) failed: %s", ksize, e.what());
+        return nullptr;
+    }
+    if (kernel.rows * kernel.cols != ksize || kernel.type() != CV_32F)
+        return nullptr;
+
+    CoeffEntry entry{};
+    entry.float_offset = _coeff_host.size();
+    for (int i = 0; i < ksize; ++i)
+        _coeff_host.push_back(kernel.at<float>(i));
+
+    std::vector<float> scaled;
+    entry.int_valid = is_smooth_symmetrical(kernel) && bit_exact_256(kernel, scaled);
+    if (entry.int_valid) {
+        entry.int_offset = _coeff_host.size();
+        _coeff_host.insert(_coeff_host.end(), scaled.begin(), scaled.end());
+    }
+
+    return &_coeff_index.emplace(ksize, entry).first->second;
+}
+
+int RendererGPU::blur_vector_elements(int n) const {
+    if (_blur_vec_lanes <= 0)
+        return 0;
+    /* Transcribed from SymmColumnVec_32s8u::operator(): a run of whole
+     * v_uint8-wide steps, then at most one v_uint16-wide one. */
+    const int v8 = _blur_vec_lanes, v16 = _blur_vec_lanes / 2;
+    int i = 0;
+    for (; i <= n - v8; i += v8)
+        ;
+    if (i <= n - v16)
+        i += v16;
+    return i;
+}
+
+void RendererGPU::calibrate_blur_rounding() {
+    /* Feeds cv::GaussianBlur an input for which every output element is an
+     * exact .5 tie, so the boundary shows up directly as a step in the output.
+     * With the length-7 kernel {8,28,56,72,56,28,8}/256 and rows that are
+     * constant in x, a single centre row of 16 gives an accumulator of
+     * 256*72*16 = 294912, i.e. 4.5: half to even writes 4, half up writes 5.
+     *
+     * Two widths are probed because one cannot tell a 64-lane vector path
+     * (which skips a 24 wide row entirely) from a build with no vector path at
+     * all (which skips both). */
+    static const struct {
+        int width;
+        int expect[3]; // lanes 16, 32, 64
+    } probes[] = {{24, {24, 16, 0}}, {100, {96, 96, 96}}};
+
+    int measured[2] = {-1, -1};
+    for (int p = 0; p < 2; ++p) {
+        const int w = probes[p].width;
+        cv::Mat plane = cv::Mat::zeros(16, w, CV_8UC1);
+        const cv::Rect rect(0, 8, w, 1);
+        plane.row(rect.y).setTo(cv::Scalar(16));
+        try {
+            cv::Mat sub = plane(rect);
+            cv::GaussianBlur(sub, sub, cv::Size(7, 7), 0);
+        } catch (const cv::Exception &e) {
+            GST_WARNING("gvawatermark GPU renderer: blur rounding calibration failed: %s", e.what());
+            return;
+        }
+        const uint8_t *out = plane.ptr<uint8_t>(rect.y);
+        int boundary = w;
+        for (int i = 0; i < w; ++i) {
+            if (out[i] != 4 && out[i] != 5) {
+                GST_WARNING("gvawatermark GPU renderer: blur rounding calibration got %d at %d, expected a .5 tie",
+                            out[i], i);
+                return;
+            }
+            if (out[i] == 5 && boundary == w) // first element the scalar tail took
+                boundary = i;
+        }
+        measured[p] = boundary;
+    }
+
+    for (int lanes : {16, 32, 64}) {
+        const int idx = lanes == 16 ? 0 : lanes == 32 ? 1 : 2;
+        if (measured[0] == probes[0].expect[idx] && measured[1] == probes[1].expect[idx]) {
+            _blur_vec_lanes = lanes;
+            return;
+        }
+    }
+    if (measured[0] == 0 && measured[1] == 0) {
+        _blur_vec_lanes = 0; // no vector column filter in this OpenCV build
+        return;
+    }
+    /* An OpenCV whose handover we cannot model. The blur still runs; small
+     * rectangles may differ from the CPU path by one on tie pixels. */
+    GST_WARNING("gvawatermark GPU renderer: unrecognized blur rounding handover (%d, %d); "
+                "blurs may differ from the CPU renderer by one on tie pixels",
+                measured[0], measured[1]);
+    _blur_vec_lanes = 32;
+}
+
+void RendererGPU::add_blur(BatchId id, const cv::Rect &rect, int cn, int kw, int kh, const CoeffEntry &cx,
+                           const CoeffEntry &cy, bool integer_regime) {
+    /* The taps reach the kernel's half width outside the rectangle, and the
+     * result depends on what is there, so the conflict box is the rectangle
+     * grown by that much rather than the rectangle itself. */
+    const int ax = kw / 2, ay = kh / 2;
+    const int x0 = rect.x - ax, y0 = rect.y - ay;
+    const int x1 = rect.x + rect.width - 1 + ax, y1 = rect.y + rect.height - 1 + ay;
+
+    flush_spans_overlapping(id & 1, x0, y0, x1, y1);
+    Group &group = exclusive_group(id, x0, y0, x1, y1);
+
+    Prim p{};
+    p.a.s[0] = rect.x;
+    p.a.s[1] = rect.y;
+    p.a.s[2] = rect.width;
+    p.a.s[3] = rect.height;
+    p.b.s[0] = kw;
+    p.b.s[1] = kh;
+    p.b.s[2] = static_cast<cl_int>(integer_regime ? cx.int_offset : cx.float_offset);
+    p.b.s[3] = static_cast<cl_int>(integer_regime ? cy.int_offset : cy.float_offset);
+    p.color.s[0] = integer_regime ? 1.f : 0.f;
+    /* The handover is always a multiple of 16 elements, so with one or two
+     * channels it never falls inside a pixel and can be passed as a column. */
+    p.color.s[1] = static_cast<float>(blur_vector_elements(rect.width * cn) / cn);
+    group.prims.push_back(p);
+
+    group.max_w = rect.width;
+    group.max_h = rect.height;
+    _scratch_needed =
+        std::max(_scratch_needed, static_cast<size_t>(rect.width) * static_cast<size_t>(rect.height + kh - 1));
+}
+
+bool RendererGPU::add_blend(BatchId id, const cv::Rect &rect, const cv::Mat &bitmap, const cl_float4 &color) {
+    if (rect.width <= 0 || rect.height <= 0)
+        return true;
+    if (bitmap.cols != rect.width || bitmap.rows != rect.height || bitmap.type() != CV_8UC1)
+        return false;
+
+    const size_t bytes = static_cast<size_t>(rect.width) * rect.height;
+    if (_blob_host.size() + bytes > BLOB_MAX_BYTES) {
+        _last_unsupported = "segmentation masks exceed the per-frame budget";
+        return false;
+    }
+    const size_t offset = _blob_host.size();
+    _blob_host.resize(offset + bytes);
+    for (int row = 0; row < rect.height; ++row)
+        std::memcpy(_blob_host.data() + offset + static_cast<size_t>(row) * rect.width, bitmap.ptr<uint8_t>(row),
+                    rect.width);
+
+    const int x1 = rect.x + rect.width - 1, y1 = rect.y + rect.height - 1;
+    flush_spans_overlapping(id & 1, rect.x, rect.y, x1, y1);
+    Group &group = exclusive_group(id, rect.x, rect.y, x1, y1);
+
+    Prim p{};
+    p.a.s[0] = rect.x;
+    p.a.s[1] = rect.y;
+    p.a.s[2] = rect.width;
+    p.a.s[3] = rect.height;
+    p.b.s[0] = static_cast<cl_int>(offset);
+    p.b.s[1] = rect.width; // blob rows are packed
+    p.color = color;
+    group.prims.push_back(p);
+
+    group.max_w = rect.width;
+    group.max_h = rect.height;
+    _scratch_needed = std::max(_scratch_needed, bytes);
+    return true;
+}
+
+void RendererGPU::insert_span(std::vector<SpanRec> &row, int a, int b, const cl_float4 &color) {
+    for (size_t i = 0; i < row.size();) {
+        const int x1 = row[i].x1, x2 = row[i].x2;
+        if (x2 < a || x1 > b) {
+            ++i;
+            continue;
+        }
+        const bool left = x1 < a, right = x2 > b;
+        if (left && right) {
+            /* The old entry is split in two. Taking a copy of the colour first
+             * matters: push_back may reallocate and invalidate row[i]. */
+            const cl_float4 old = row[i].color;
+            row[i].x2 = a - 1;
+            row.push_back({b + 1, x2, old});
+            ++i; // the remnant just appended cannot overlap [a, b]
+        } else if (left) {
+            row[i].x2 = a - 1;
+            ++i;
+        } else if (right) {
+            row[i].x1 = b + 1;
+            ++i;
+        } else {
+            /* Fully covered. Entries are unordered and disjoint, so the last one
+             * can be swapped in - and must then be tested in turn. */
+            row[i] = row.back();
+            row.pop_back();
+        }
+    }
+    row.push_back({a, b, color});
+}
+
+bool RendererGPU::add_raster(BatchId span_id, const renderer_gpu::Raster &raster, const cl_float4 &color) {
+    const int plane = span_id & 1;
+    std::vector<std::vector<SpanRec>> &rows = _span_rows[plane];
+    const int w = plane_width(plane);
+
+    /* The rasterizers emit a primitive as spans (FillConvexPoly's scanline
+     * walk, disc rows) plus loose pixels (the Line2 edge strokes, thin
+     * Bresenham lines). Coalescing them per row first is exact - every record of
+     * one primitive carries the same colour, so overlapping and abutting
+     * intervals can be fused without changing which pixels end up painted - and
+     * it keeps both the number of insertions below and the kernel's work size
+     * down to the longest run rather than one work item per loose pixel. */
+    _merge.clear();
+    _merge.reserve(raster.size());
+    for (const renderer_gpu::Raster::Run &run : raster.runs)
+        _merge.push_back({run.y, run.x1, run.x2});
+    for (const cv::Point &pt : raster.points)
+        _merge.push_back({pt.y, pt.x, pt.x});
+
+    std::sort(_merge.begin(), _merge.end(), [](const Span &a, const Span &b) {
+        return a.y != b.y ? a.y < b.y : a.x1 < b.x1;
+    });
+
+    /* Runs go into the per-row lists rather than straight into a group, because
+     * work items of one NDRange are unordered: two records covering the same
+     * pixel with different colours would race, and the frame would not even be
+     * reproducible. insert_span() resolves the overlap on the host, in painter's
+     * order, so what reaches the device is a disjoint set - one dispatch,
+     * whatever pile of shapes went into it, matching the CPU renderer exactly. */
+    for (size_t i = 0; i < _merge.size();) {
+        Span cur = _merge[i++];
+        while (i < _merge.size() && _merge[i].y == cur.y && _merge[i].x1 <= cur.x2 + 1)
+            cur.x2 = std::max(cur.x2, _merge[i++].x2);
+
+        if (cur.y < 0 || cur.y >= static_cast<int>(rows.size()) || cur.x2 < 0 || cur.x1 >= w)
+            continue;
+        cur.x1 = std::max(cur.x1, 0);
+        cur.x2 = std::min(cur.x2, w - 1);
+
+        // One insertion nets at most two records: the new one plus a split remnant.
+        if (_span_records + 2 > RASTER_MAX_RECORDS) {
+            _last_unsupported = "primitive rasterizes to too many runs";
+            return false;
+        }
+
+        std::vector<SpanRec> &row = rows[cur.y];
+        const size_t before = row.size();
+        insert_span(row, cur.x1, cur.x2, color);
+        const size_t after = row.size();
+        if (_span_pending[plane] == 0)
+            _span_box[plane] = {cur.x1, cur.y, cur.x2, cur.y};
+        _span_pending[plane] = _span_pending[plane] + after - before;
+        _span_records = _span_records + after - before;
+
+        std::array<int, 4> &box = _span_box[plane];
+        box[0] = std::min(box[0], cur.x1);
+        box[1] = std::min(box[1], cur.y);
+        box[2] = std::max(box[2], cur.x2);
+        box[3] = std::max(box[3], cur.y);
+    }
+    return true;
+}
+
+void RendererGPU::flush_spans(int plane) {
+    if (_span_pending[plane] == 0)
+        return;
+
+    const std::array<int, 4> &box = _span_box[plane];
+    const BatchId id = plane == 0 ? SPAN_P0 : SPAN_P1;
+    /* One conflict box for the whole set, flagged any_color: the runs carry many
+     * colours, and a later primitive only needs to know that something was
+     * painted under it. */
+    cl_float4 unused{};
+    Group &group = group_for(id, box[0], box[1], box[2], box[3], unused, true);
+
+    std::vector<std::vector<SpanRec>> &rows = _span_rows[plane];
+    for (size_t y = 0; y < rows.size(); ++y) {
+        for (const SpanRec &rec : rows[y]) {
+            Prim p{};
+            p.a.s[0] = rec.x1;
+            p.a.s[1] = rec.x2;
+            p.a.s[2] = static_cast<cl_int>(y);
+            p.color = rec.color;
+            group.prims.push_back(p);
+            group.max_w = std::max(group.max_w, rec.x2 - rec.x1 + 1);
+            group.max_h = 1;
+        }
+        rows[y].clear();
+    }
+    _span_pending[plane] = 0;
+}
+
+void RendererGPU::flush_spans_overlapping(int plane, int x0, int y0, int x1, int y1) {
+    if (_span_pending[plane] == 0)
+        return;
+    const std::array<int, 4> &box = _span_box[plane];
+    if (x1 < box[0] || x0 > box[2] || y1 < box[1] || y0 > box[3])
+        return;
+    flush_spans(plane);
+}
+
+bool RendererGPU::flatten_rect(const render::Rect &rect) {
+    if (rect.rotation != 0.0) {
+        _last_unsupported = "rotated rectangle (obb=true)";
+        return false;
+    }
+    if (rect.thick <= 0) {
+        _last_unsupported = "filled rectangle";
+        return false;
+    }
+
+    /* RendererI420/NV12::draw_rectangle aligns the bottom-right with
+     * render::render by subtracting (1, 1). */
+    const cv::Point tl = rect.rect.tl();
+    const cv::Point br = rect.rect.br() - cv::Point(1, 1);
+    const int thick = half_thickness(rect.thick);
+    const int k = band_half_width(thick);
+
+    add_outline(OUTLINE_P1, half_coord(tl.x), half_coord(tl.y), half_coord(br.x), half_coord(br.y), k,
+                plane_color_uv(rect.color));
+
+    /* draw_rect_y_plane(): every U/V pixel covers two Y pixels, so the Y plane
+     * gets the same half-thickness outline twice, the second one nudged by the
+     * coordinate parity, to avoid a chroma shadow. */
+    const cl_float4 color_y = plane_color_y(rect.color);
+    add_outline(OUTLINE_P0, tl.x, tl.y, br.x, br.y, k, color_y);
+    add_outline(OUTLINE_P0, tl.x + (tl.x % 2 ? -1 : 1), tl.y + (tl.y % 2 ? -1 : 1), br.x + (br.x % 2 ? -1 : 1),
+                br.y + (br.y % 2 ? -1 : 1), k, color_y);
+    return true;
+}
+
+bool RendererGPU::flatten_text(const render::Text &text) {
+    if (text.text.empty())
+        return true;
+
+    /* draw_text_bg fills the background with the primitive colour and draw_text
+     * then writes the label in white, which is (255, 128, 128) in NV12. */
+    if (text.draw_bg) {
+        int baseline = 0;
+        const cv::Size size = cv::getTextSize(text.text, text.fonttype, text.fontscale, text.thick, &baseline);
+        const cv::Point bg_tl(text.org.x, text.org.y - size.height);
+        const cv::Point bg_br(text.org.x + size.width, text.org.y + baseline);
+        add_fill(FILL_P0, bg_tl.x, bg_tl.y, bg_br.x, bg_br.y, plane_color_y(text.color));
+        add_fill(FILL_P1, half_coord(bg_tl.x), half_coord(bg_tl.y), half_coord(bg_br.x), half_coord(bg_br.y),
+                 plane_color_uv(text.color));
+    }
+
+    const cv::Scalar color = text.draw_bg ? cv::Scalar(255, 128, 128) : text.color;
+
+    const AtlasEntry *y_entry = rasterize_text(text.text, text.fonttype, text.fontscale, text.thick);
+    if (!y_entry) {
+        _last_unsupported = "text rasterization failed";
+        return false;
+    }
+    add_mask(MASK_P0, *y_entry, text.org.x + y_entry->origin_x, text.org.y + y_entry->origin_y, plane_color_y(color));
+
+    /* The U/V planes carry an independently rasterized label at half the font
+     * scale and half the thickness, drawn at half the position. */
+    const int uv_thick = half_thickness(text.thick);
+    const AtlasEntry *uv_entry = rasterize_text(text.text, text.fonttype, text.fontscale / 2.0, uv_thick);
+    if (!uv_entry) {
+        _last_unsupported = "text rasterization failed";
+        return false;
+    }
+    add_mask(MASK_P1, *uv_entry, half_coord(text.org.x) + uv_entry->origin_x,
+             half_coord(text.org.y) + uv_entry->origin_y, plane_color_uv(color));
+    return true;
+}
+
+bool RendererGPU::flatten_line(const render::Line &line) {
+    /* cv::line asserts thickness > 0; the CPU renderer would throw too. */
+    if (line.thick <= 0) {
+        _last_unsupported = "line with non-positive thickness";
+        return false;
+    }
+
+    /* RendererNV12::draw_line draws the Y plane at the *full* thickness and with
+     * no parity double-draw - unlike draw_rectangle, which halves the thickness
+     * and draws twice. Only the U/V plane halves coordinates and thickness.
+     * cv::line caps both endpoints, hence caps == 3. */
+    _raster.clear();
+    renderer_gpu::thick_line(line.pt1, line.pt2, line.thick, 3, _width, _height, _raster);
+    if (!add_raster(SPAN_P0, _raster, plane_color_y(line.color)))
+        return false;
+
+    _raster.clear();
+    renderer_gpu::thick_line({half_coord(line.pt1.x), half_coord(line.pt1.y)},
+                             {half_coord(line.pt2.x), half_coord(line.pt2.y)}, half_thickness(line.thick), 3,
+                             _width / 2, _height / 2, _raster);
+    return add_raster(SPAN_P1, _raster, plane_color_uv(line.color));
+}
+
+bool RendererGPU::flatten_circle(const render::Circle &circle) {
+    /* cv::circle only *fills* for thickness < 0; thickness 0 and 1 both draw the
+     * one-pixel Bresenham arc, and thickness > 1 goes to EllipseEx, which
+     * strokes an arc polyline and is not ported. In-tree generators (landmarks,
+     * keypoints) always pass cv::FILLED; the other thicknesses only arrive
+     * through a user-supplied WatermarkCircleMeta. */
+    if (circle.thick > 1) {
+        _last_unsupported = "circle outline with thickness > 1";
+        return false;
+    }
+    if (circle.radius < 0) {
+        _last_unsupported = "circle with negative radius";
+        return false;
+    }
+    const bool fill = circle.thick < 0;
+
+    /* RendererNV12::draw_circle halves the radius and the thickness for the U/V
+     * plane. calc_thick_for_u_v_planes() leaves thickness <= 1 alone, so the
+     * fill/outline choice is the same on both planes. */
+    _raster.clear();
+    if (fill)
+        renderer_gpu::filled_disc(circle.center.x, circle.center.y, circle.radius, _width, _height, _raster);
+    else
+        renderer_gpu::circle_outline(circle.center.x, circle.center.y, circle.radius, _width, _height, _raster);
+    if (!add_raster(SPAN_P0, _raster, plane_color_y(circle.color)))
+        return false;
+
+    const int uv_cx = half_coord(circle.center.x), uv_cy = half_coord(circle.center.y);
+    const int uv_r = circle.radius / 2, uv_w = _width / 2, uv_h = _height / 2;
+    _raster.clear();
+    if (fill)
+        renderer_gpu::filled_disc(uv_cx, uv_cy, uv_r, uv_w, uv_h, _raster);
+    else
+        renderer_gpu::circle_outline(uv_cx, uv_cy, uv_r, uv_w, uv_h, _raster);
+    return add_raster(SPAN_P1, _raster, plane_color_uv(circle.color));
+}
+
+bool RendererGPU::flatten_polygon(const render::Polygon &polygon) {
+    /* Negative thickness makes cv::drawContours fill the contour instead of
+     * stroking it, which is a different rasterizer. */
+    if (polygon.thick <= 0) {
+        _last_unsupported = "filled polygon";
+        return false;
+    }
+    if (polygon.points.empty())
+        return true;
+
+    /* cv::drawContours strokes every edge of the closed contour with
+     * ThickLine(flags = 2), which caps only the far endpoint so a shared vertex
+     * is not capped twice. */
+    const int n = static_cast<int>(polygon.points.size());
+    _raster.clear();
+    for (int i = 0; i < n; ++i)
+        renderer_gpu::thick_line(polygon.points[i], polygon.points[(i + 1) % n], polygon.thick, 2, _width, _height,
+                                 _raster);
+    if (!add_raster(SPAN_P0, _raster, plane_color_y(polygon.color)))
+        return false;
+
+    const int uv_thick = half_thickness(polygon.thick);
+    _raster.clear();
+    for (int i = 0; i < n; ++i) {
+        const cv::Point &a = polygon.points[i];
+        const cv::Point &b = polygon.points[(i + 1) % n];
+        renderer_gpu::thick_line({half_coord(a.x), half_coord(a.y)}, {half_coord(b.x), half_coord(b.y)}, uv_thick, 2,
+                                 _width / 2, _height / 2, _raster);
+    }
+    return add_raster(SPAN_P1, _raster, plane_color_uv(polygon.color));
+}
+
+bool RendererGPU::flatten_blur(const render::Blur &blur) {
+    const cv::Rect &r = blur.rect;
+
+    /* blur_rectangle builds its submatrices with the plain cv::Mat(mat, rect)
+     * constructor, which throws on anything the plane does not fully contain.
+     * Declining here keeps that a CPU-path decision instead of letting the GPU
+     * quietly render something the golden never would. Two pixels in each
+     * direction are needed, or the halved chroma rectangle is empty. */
+    if (r.width < 2 || r.height < 2 || r.x < 0 || r.y < 0 || r.x + r.width > _width || r.y + r.height > _height) {
+        _last_unsupported = "blur rectangle outside the frame";
+        return false;
+    }
+
+    /* Order matters and is not the obvious one: blur_rectangle does U/V first
+     * and Y second. Only the plane ordering is observable here, since the two
+     * planes are independent images, but keeping it makes the two renderers
+     * line up line for line. Each plane gets its own kernel size - blurring
+     * only Y would leave a sharp chroma outline. */
+    const cv::Rect uv(r.x / 2, r.y / 2, r.width / 2, r.height / 2);
+    const cv::Size ks_uv = render::computeBlurKernelSize(r.width / 2, r.height / 2);
+    const cv::Size ks_y = render::computeBlurKernelSize(r.width, r.height);
+
+    struct Job {
+        BatchId id;
+        cv::Rect rect;
+        cv::Size ksize;
+        int cn;
+    } jobs[2] = {{BLUR_P1, uv, ks_uv, 2}, {BLUR_P0, r, ks_y, 1}};
+
+    for (const Job &job : jobs) {
+        if (job.rect.width <= 0 || job.rect.height <= 0)
+            continue;
+        const CoeffEntry *cx = gaussian_coeffs(job.ksize.width);
+        const CoeffEntry *cy = gaussian_coeffs(job.ksize.height);
+        if (!cx || !cy) {
+            _last_unsupported = "Gaussian kernel construction failed";
+            return false;
+        }
+        /* sepFilter2D takes the integer fixed-point path only when *both*
+         * kernels quantize exactly, so the decision is per blur, not per
+         * kernel. In practice that means the small kernels of a small ROI. */
+        add_blur(job.id, job.rect, job.cn, job.ksize.width, job.ksize.height, *cx, *cy,
+                 cx->int_valid && cy->int_valid);
+    }
+    return true;
+}
+
+bool RendererGPU::flatten_instance_mask(const render::InstanceSegmantationMask &mask) {
+    if (mask.size.width <= 0 || mask.size.height <= 0 ||
+        mask.data.size() != static_cast<size_t>(mask.size.area())) {
+        _last_unsupported = "malformed instance segmentation mask";
+        return false;
+    }
+
+    /* Everything up to the blend is draw_instance_mask verbatim,
+     * run on the CPU with OpenCV: the resampling and thresholding are cheap
+     * next to a full-frame round trip, and doing them with the same calls is
+     * the only way to be sure the coverage bitmap is the same one. Only the
+     * final addWeighted + copyTo, which touches the frame, moves to the GPU. */
+    cv::Mat unpadded(mask.size, CV_32F, const_cast<float *>(mask.data.data()));
+    cv::Mat raw_cls_mask;
+    cv::Mat resized_y, resized_uv, binary_y, binary_uv;
+    cv::Rect roi_y, roi_uv;
+    try {
+        cv::copyMakeBorder(unpadded, raw_cls_mask, 1, 1, 1, 1, cv::BORDER_CONSTANT, {0});
+        const cv::Rect box = expand_box(mask.box, float(raw_cls_mask.cols) / (raw_cls_mask.cols - 2),
+                                        float(raw_cls_mask.rows) / (raw_cls_mask.rows - 2));
+
+        const int w = std::max(box.width + 1, 1);
+        const int h = std::max(box.height + 1, 1);
+        const int x0_y = clamp_to(box.x, 0, _width);
+        const int y0_y = clamp_to(box.y, 0, _height);
+        const int x1_y = clamp_to(box.x + box.width + 1, 0, _width);
+        const int y1_y = clamp_to(box.y + box.height + 1, 0, _height);
+        const int x0_uv = half_coord(x0_y), y0_uv = half_coord(y0_y);
+        const int x1_uv = half_coord(x1_y), y1_uv = half_coord(y1_y);
+
+        roi_y = cv::Rect(x0_y, y0_y, x1_y - x0_y, y1_y - y0_y);
+        roi_uv = cv::Rect(x0_uv, y0_uv, x1_uv - x0_uv, y1_uv - y0_uv);
+        if (roi_y.width <= 0 || roi_y.height <= 0)
+            return true; // nothing of the mask lands on the frame
+
+        cv::resize(raw_cls_mask, resized_y, {w, h});
+
+        cv::threshold(resized_y({cv::Point(x0_y - box.x, y0_y - box.y), cv::Point(x1_y - box.x, y1_y - box.y)}),
+                      binary_y, 0.5f, 1.0f, cv::THRESH_BINARY);
+        binary_y.convertTo(binary_y, CV_8U);
+
+        if (roi_uv.width > 0 && roi_uv.height > 0) {
+            cv::resize(raw_cls_mask, resized_uv, {half_coord(w) + 1, half_coord(h) + 1});
+            const int bx_uv = half_coord(box.x), by_uv = half_coord(box.y);
+            cv::threshold(resized_uv({cv::Point(x0_uv - bx_uv, y0_uv - by_uv),
+                                      cv::Point(x1_uv - bx_uv, y1_uv - by_uv)}),
+                          binary_uv, 0.5f, 1.0f, cv::THRESH_BINARY);
+            binary_uv.convertTo(binary_uv, CV_8U);
+        }
+    } catch (const cv::Exception &e) {
+        GST_WARNING("gvawatermark GPU renderer: instance mask preparation failed: %s", e.what());
+        _last_unsupported = "instance segmentation mask preparation failed";
+        return false;
+    }
+
+    if (!add_blend(BLEND_P0, roi_y, binary_y, plane_color_y(mask.color)))
+        return false;
+    if (roi_uv.width > 0 && roi_uv.height > 0 && !add_blend(BLEND_P1, roi_uv, binary_uv, plane_color_uv(mask.color)))
+        return false;
+    return true;
+}
+
+bool RendererGPU::flatten(std::vector<render::Prim> &prims) {
+    /* Groups are reset lazily as group_for() hands them out, so the vectors keep
+     * their storage; only the used count is dropped here. Pending runs can
+     * survive a frame that bailed out mid-flatten, hence the explicit clear. */
+    _group_count = {0, 0};
+    for (int plane = 0; plane < 2; ++plane) {
+        if (_span_pending[plane] == 0)
+            continue;
+        for (std::vector<SpanRec> &row : _span_rows[plane])
+            row.clear();
+        _span_pending[plane] = 0;
+    }
+    _span_records = 0;
+    _blob_host.clear();
+    _scratch_needed = 0;
+
+    /* Drop the atlas before it can grow without bound; must happen before any
+     * offsets are handed out for this frame. */
+    if (_atlas_host.size() > ATLAS_MAX_BYTES || _atlas_index.size() > ATLAS_MAX_ENTRIES) {
+        _atlas_index.clear();
+        _atlas_host.clear();
+        _atlas_uploaded = 0;
+    }
+
+    for (const render::Prim &prim : prims) {
+        if (const auto *rect = std::get_if<render::Rect>(&prim)) {
+            if (!flatten_rect(*rect))
+                return false;
+        } else if (const auto *text = std::get_if<render::Text>(&prim)) {
+            if (!flatten_text(*text))
+                return false;
+        } else if (const auto *line = std::get_if<render::Line>(&prim)) {
+            if (!flatten_line(*line))
+                return false;
+        } else if (const auto *circle = std::get_if<render::Circle>(&prim)) {
+            if (!flatten_circle(*circle))
+                return false;
+        } else if (const auto *polygon = std::get_if<render::Polygon>(&prim)) {
+            if (!flatten_polygon(*polygon))
+                return false;
+        } else if (const auto *blur = std::get_if<render::Blur>(&prim)) {
+            if (!flatten_blur(*blur))
+                return false;
+        } else if (const auto *mask = std::get_if<render::InstanceSegmantationMask>(&prim)) {
+            if (!flatten_instance_mask(*mask))
+                return false;
+        } else {
+            /* Not ported, and there is nothing to port to:
+             * RendererNV12::draw_semantic_mask throws std::logic_error. */
+            _last_unsupported = "semantic segmentation mask";
+            return false;
+        }
+    }
+
+    for (int plane = 0; plane < 2; ++plane)
+        flush_spans(plane);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// CPU text rasterization
+// ---------------------------------------------------------------------------
+
+const RendererGPU::AtlasEntry *RendererGPU::rasterize_text(const std::string &text, int fonttype, double fontscale,
+                                                           int thick) {
+    char params[64];
+    std::snprintf(params, sizeof(params), "\x1f%d\x1f%.6f\x1f%d", fonttype, fontscale, thick);
+    std::string key = text + params;
+
+    if (auto it = _atlas_index.find(key); it != _atlas_index.end())
+        return &it->second;
+
+    int baseline = 0;
+    cv::Size size;
+    try {
+        size = cv::getTextSize(text, fonttype, fontscale, std::max(1, thick), &baseline);
+    } catch (const cv::Exception &e) {
+        GST_WARNING("gvawatermark GPU renderer: getTextSize failed: %s", e.what());
+        return nullptr;
+    }
+    if (size.width <= 0 || size.height <= 0)
+        return nullptr;
+
+    /* Rasterize into a padded bitmap so thick strokes, accents and descenders
+     * cannot be clipped differently than cv::putText would draw them straight
+     * into the plane. Verified pixel-identical to a direct putText. */
+    const int pad = std::max(1, thick) + 4;
+    const int width = size.width + 2 * pad;
+    const int height = size.height + baseline + 2 * pad;
+
+    cv::Mat mask = cv::Mat::zeros(height, width, CV_8UC1);
+    try {
+        cv::putText(mask, text, cv::Point(pad, pad + size.height), fonttype, fontscale, cv::Scalar(255),
+                    std::max(1, thick), cv::LINE_8);
+    } catch (const cv::Exception &e) {
+        GST_WARNING("gvawatermark GPU renderer: putText failed: %s", e.what());
+        return nullptr;
+    }
+
+    AtlasEntry entry{};
+    entry.offset = _atlas_host.size();
+    entry.width = width;
+    entry.height = height;
+    entry.origin_x = -pad;
+    entry.origin_y = -(size.height + pad);
+
+    _atlas_host.resize(entry.offset + static_cast<size_t>(width) * height);
+    uint8_t *dst = _atlas_host.data() + entry.offset;
+    for (int row = 0; row < height; ++row)
+        std::memcpy(dst + static_cast<size_t>(row) * width, mask.ptr<uint8_t>(row), width);
+
+    return &_atlas_index.emplace(std::move(key), entry).first->second;
+}
+
+// ---------------------------------------------------------------------------
+// Device transfers
+// ---------------------------------------------------------------------------
+
+bool RendererGPU::sync_atlas() {
+    if (_atlas_host.empty())
+        return true;
+
+    if (_atlas_buffer_capacity < _atlas_host.size()) {
+        size_t capacity = std::max<size_t>(64u << 10, _atlas_buffer_capacity * 2);
+        while (capacity < _atlas_host.size())
+            capacity *= 2;
+        cl_int err = CL_SUCCESS;
+        cl_mem buffer = clCreateBuffer(_shared->context, CL_MEM_READ_ONLY, capacity, nullptr, &err);
+        if (!buffer || !cl_ok(err, "clCreateBuffer(atlas)"))
+            return false;
+        if (_atlas_buffer)
+            clReleaseMemObject(_atlas_buffer);
+        _atlas_buffer = buffer;
+        _atlas_buffer_capacity = capacity;
+        _atlas_uploaded = 0; // fresh allocation, re-upload everything
+    }
+
+    if (_atlas_uploaded < _atlas_host.size()) {
+        const size_t bytes = _atlas_host.size() - _atlas_uploaded;
+        if (!cl_ok(clEnqueueWriteBuffer(_queue, _atlas_buffer, CL_FALSE, _atlas_uploaded, bytes,
+                                        _atlas_host.data() + _atlas_uploaded, 0, nullptr, nullptr),
+                   "clEnqueueWriteBuffer(atlas)"))
+            return false;
+        _atlas_uploaded = _atlas_host.size();
+    }
+    return true;
+}
+
+bool RendererGPU::sync_coeffs() {
+    if (_coeff_host.empty())
+        return true;
+
+    const size_t bytes = _coeff_host.size() * sizeof(float);
+    if (_coeff_buffer_capacity < bytes) {
+        size_t capacity = std::max<size_t>(4u << 10, _coeff_buffer_capacity * 2);
+        while (capacity < bytes)
+            capacity *= 2;
+        cl_int err = CL_SUCCESS;
+        cl_mem buffer = clCreateBuffer(_shared->context, CL_MEM_READ_ONLY, capacity, nullptr, &err);
+        if (!buffer || !cl_ok(err, "clCreateBuffer(coeffs)"))
+            return false;
+        if (_coeff_buffer)
+            clReleaseMemObject(_coeff_buffer);
+        _coeff_buffer = buffer;
+        _coeff_buffer_capacity = capacity;
+        _coeff_uploaded = 0;
+    }
+
+    /* Append-only, like the atlas: entries are never rewritten, so only the
+     * tail added since the last frame has to go across. */
+    if (_coeff_uploaded < bytes) {
+        if (!cl_ok(clEnqueueWriteBuffer(_queue, _coeff_buffer, CL_FALSE, _coeff_uploaded, bytes - _coeff_uploaded,
+                                        reinterpret_cast<const uint8_t *>(_coeff_host.data()) + _coeff_uploaded, 0,
+                                        nullptr, nullptr),
+                   "clEnqueueWriteBuffer(coeffs)"))
+            return false;
+        _coeff_uploaded = bytes;
+    }
+    return true;
+}
+
+bool RendererGPU::sync_blob() {
+    if (_blob_host.empty())
+        return true;
+
+    if (_blob_buffer_capacity < _blob_host.size()) {
+        size_t capacity = std::max<size_t>(256u << 10, _blob_buffer_capacity * 2);
+        while (capacity < _blob_host.size())
+            capacity *= 2;
+        cl_int err = CL_SUCCESS;
+        cl_mem buffer = clCreateBuffer(_shared->context, CL_MEM_READ_ONLY, capacity, nullptr, &err);
+        if (!buffer || !cl_ok(err, "clCreateBuffer(blob)"))
+            return false;
+        if (_blob_buffer)
+            clReleaseMemObject(_blob_buffer);
+        _blob_buffer = buffer;
+        _blob_buffer_capacity = capacity;
+    }
+
+    return cl_ok(clEnqueueWriteBuffer(_queue, _blob_buffer, CL_FALSE, 0, _blob_host.size(), _blob_host.data(), 0,
+                                      nullptr, nullptr),
+                 "clEnqueueWriteBuffer(blob)");
+}
+
+bool RendererGPU::sync_scratch() {
+    if (_scratch_needed == 0 || _scratch_buffer_capacity >= _scratch_needed)
+        return true;
+
+    size_t capacity = std::max<size_t>(1u << 16, _scratch_buffer_capacity * 2);
+    while (capacity < _scratch_needed)
+        capacity *= 2;
+    cl_int err = CL_SUCCESS;
+    cl_mem buffer = clCreateBuffer(_shared->context, CL_MEM_READ_WRITE, capacity * sizeof(cl_float2), nullptr, &err);
+    if (!buffer || !cl_ok(err, "clCreateBuffer(scratch)"))
+        return false;
+    if (_scratch_buffer)
+        clReleaseMemObject(_scratch_buffer);
+    _scratch_buffer = buffer;
+    _scratch_buffer_capacity = capacity;
+    return true;
+}
+
+bool RendererGPU::sync_prims() {
+    _prims.clear();
+    for (int plane = 0; plane < 2; ++plane) {
+        for (size_t i = 0; i < _group_count[plane]; ++i) {
+            Group &group = _groups[plane][i];
+            group.base = static_cast<int>(_prims.size());
+            _prims.insert(_prims.end(), group.prims.begin(), group.prims.end());
+        }
+    }
+    if (_prims.empty())
+        return true;
+
+    const size_t bytes = _prims.size() * sizeof(Prim);
+    if (_prim_buffer_capacity < bytes) {
+        size_t capacity = std::max<size_t>(64 * sizeof(Prim), _prim_buffer_capacity * 2);
+        while (capacity < bytes)
+            capacity *= 2;
+        cl_int err = CL_SUCCESS;
+        cl_mem buffer = clCreateBuffer(_shared->context, CL_MEM_READ_ONLY, capacity, nullptr, &err);
+        if (!buffer || !cl_ok(err, "clCreateBuffer(prims)"))
+            return false;
+        if (_prim_buffer)
+            clReleaseMemObject(_prim_buffer);
+        _prim_buffer = buffer;
+        _prim_buffer_capacity = capacity;
+    }
+
+    return cl_ok(clEnqueueWriteBuffer(_queue, _prim_buffer, CL_FALSE, 0, bytes, _prims.data(), 0, nullptr, nullptr),
+                 "clEnqueueWriteBuffer(prims)");
+}
+
+bool RendererGPU::get_planes(VASurfaceID surface, cl_mem planes[2]) {
+    if (auto it = _plane_cache.find(surface); it != _plane_cache.end()) {
+        planes[0] = it->second[0];
+        planes[1] = it->second[1];
+        return true;
+    }
+
+    VASurfaceID id = surface;
+    std::array<cl_mem, 2> imported = {nullptr, nullptr};
+    for (int plane = 0; plane < 2; ++plane) {
+        cl_int err = CL_SUCCESS;
+        imported[plane] = _shared->create_from_va(_shared->context, CL_MEM_READ_WRITE, &id, plane, &err);
+        if (!imported[plane] || err != CL_SUCCESS) {
+            char what[64];
+            std::snprintf(what, sizeof(what), "clCreateFromVA_APIMediaSurfaceINTEL(plane %d)", plane);
+            cl_ok(err, what);
+            for (cl_mem done : imported) {
+                if (done)
+                    clReleaseMemObject(done);
+            }
+            _last_unsupported = "surface cannot be imported into OpenCL";
+            return false;
+        }
+    }
+
+    _plane_cache.emplace(surface, imported);
+    planes[0] = imported[0];
+    planes[1] = imported[1];
+    return true;
+}
+
+bool RendererGPU::enqueue(const Group &group, cl_mem image, int image_w, int image_h) {
+    if (group.prims.empty())
+        return true;
+
+    /* The read-modify-write primitives are a pair of dispatches over one
+     * scratch buffer rather than a single kernel over a prim array, so they get
+     * their own argument shape. Both passes take the same prim, and the queue
+     * is in-order, which is the only synchronization the pair needs. */
+    if (group.id == BLUR_P0 || group.id == BLUR_P1 || group.id == BLEND_P0 || group.id == BLEND_P1) {
+        const bool is_blur = (group.id == BLUR_P0 || group.id == BLUR_P1);
+        const Prim &p = group.prims[0];
+        const cl_int base = group.base;
+        cl_kernel passes[2] = {is_blur ? _k_blur_h : _k_blend_gather, is_blur ? _k_blur_v : _k_blend_scatter};
+        // The blur's row pass also covers the kh - 1 rows the column pass reaches into.
+        const size_t rows[2] = {static_cast<size_t>(is_blur ? p.a.s[3] + p.b.s[1] - 1 : p.a.s[3]),
+                                static_cast<size_t>(p.a.s[3])};
+        cl_mem side = is_blur ? _coeff_buffer : _blob_buffer;
+        if (!side) {
+            GST_WARNING("gvawatermark GPU renderer: %s dispatch without its data buffer",
+                        is_blur ? "blur" : "blend");
+            return false;
+        }
+
+        for (int pass = 0; pass < 2; ++pass) {
+            cl_uint arg = 0;
+            cl_int err = CL_SUCCESS;
+            err |= clSetKernelArg(passes[pass], arg++, sizeof(cl_mem), &image);
+            err |= clSetKernelArg(passes[pass], arg++, sizeof(cl_int), &image_w);
+            err |= clSetKernelArg(passes[pass], arg++, sizeof(cl_int), &image_h);
+            err |= clSetKernelArg(passes[pass], arg++, sizeof(cl_mem), &_scratch_buffer);
+            err |= clSetKernelArg(passes[pass], arg++, sizeof(cl_mem), &side);
+            err |= clSetKernelArg(passes[pass], arg++, sizeof(cl_mem), &_prim_buffer);
+            err |= clSetKernelArg(passes[pass], arg++, sizeof(cl_int), &base);
+            if (!cl_ok(err, "clSetKernelArg"))
+                return false;
+
+            const size_t global[2] = {static_cast<size_t>(p.a.s[2]), rows[pass]};
+            if (global[0] == 0 || global[1] == 0)
+                return true;
+            if (!cl_ok(clEnqueueNDRangeKernel(_queue, passes[pass], 2, nullptr, global, nullptr, 0, nullptr, nullptr),
+                       "clEnqueueNDRangeKernel"))
+                return false;
+        }
+        return true;
+    }
+
+    cl_kernel kernel = nullptr;
+    bool with_atlas = false;
+    switch (group.id) {
+    case SPAN_P0:
+    case SPAN_P1:
+        kernel = _k_spans;
+        break;
+    case OUTLINE_P0:
+    case OUTLINE_P1:
+        kernel = _k_outlines;
+        break;
+    case FILL_P0:
+    case FILL_P1:
+        kernel = _k_fills;
+        break;
+    default:
+        kernel = _k_masks;
+        with_atlas = true;
+        break;
+    }
+
+    const cl_int base = group.base;
+    cl_uint arg = 0;
+    cl_int err = CL_SUCCESS;
+    err |= clSetKernelArg(kernel, arg++, sizeof(cl_mem), &image);
+    err |= clSetKernelArg(kernel, arg++, sizeof(cl_int), &image_w);
+    err |= clSetKernelArg(kernel, arg++, sizeof(cl_int), &image_h);
+    if (with_atlas)
+        err |= clSetKernelArg(kernel, arg++, sizeof(cl_mem), &_atlas_buffer);
+    err |= clSetKernelArg(kernel, arg++, sizeof(cl_mem), &_prim_buffer);
+    err |= clSetKernelArg(kernel, arg++, sizeof(cl_int), &base);
+    if (!cl_ok(err, "clSetKernelArg"))
+        return false;
+
+    /* One work item per candidate pixel. Outlines multiply the third dimension
+     * by the four edges plus the four corner discs of the rectangle. */
+    const bool is_outline = (group.id == OUTLINE_P0 || group.id == OUTLINE_P1);
+    const size_t global[3] = {static_cast<size_t>(group.max_w), static_cast<size_t>(group.max_h),
+                              group.prims.size() * (is_outline ? 8u : 1u)};
+    if (global[0] == 0 || global[1] == 0 || global[2] == 0)
+        return true;
+
+    return cl_ok(clEnqueueNDRangeKernel(_queue, kernel, 3, nullptr, global, nullptr, 0, nullptr, nullptr),
+                 "clEnqueueNDRangeKernel");
+}
+
+// ---------------------------------------------------------------------------
+// Frame entry point
+// ---------------------------------------------------------------------------
+
+bool RendererGPU::draw_surface(VASurfaceID surface, std::vector<render::Prim> prims) {
+    if (surface == VA_INVALID_SURFACE)
+        return false;
+
+    /* Imported first, before any of the per-frame work: this is where a surface
+     * that does not import the way the kernels expect is caught, and that
+     * verdict must be reached while falling back to the CPU renderer is still
+     * free. */
+    cl_mem planes[2] = {nullptr, nullptr};
+    if (!get_planes(surface, planes))
+        return false;
+
+    /* Convert primitive colours to the frame's native colour space on the CPU,
+     * exactly like Renderer::draw does, so the kernels only ever write bytes. */
+    render::convert_prims_color(prims, *_color_converter);
+
+    if (!flatten(prims))
+        return false;
+    if (!sync_prims())
+        return false;
+    if (_prims.empty())
+        return true;
+    if (!sync_atlas() || !sync_coeffs() || !sync_blob() || !sync_scratch())
+        return false;
+
+    const cl_uint n_planes = 2;
+    if (!cl_ok(_shared->acquire(_queue, n_planes, planes, 0, nullptr, nullptr),
+               "clEnqueueAcquireVA_APIMediaSurfacesINTEL"))
+        return false;
+
+    /* The queue is in-order, so the groups of one plane execute in the order
+     * they were scheduled, which is the CPU renderer's draw order wherever that
+     * is observable. The two planes are separate images and need no ordering
+     * against each other. */
+    bool ok = true;
+    for (int plane = 0; plane < 2 && ok; ++plane) {
+        for (size_t i = 0; i < _group_count[plane] && ok; ++i)
+            ok = enqueue(_groups[plane][i], planes[plane], plane_width(plane), plane_height(plane));
+    }
+
+    /* Release makes the writes visible to VA; the following finish makes them
+     * visible to the downstream element. */
+    cl_ok(_shared->release(_queue, n_planes, planes, 0, nullptr, nullptr),
+          "clEnqueueReleaseVA_APIMediaSurfacesINTEL");
+    if (!cl_ok(clFinish(_queue), "clFinish"))
+        return false;
+
+    if (!ok)
+        _last_unsupported = "OpenCL enqueue failed";
+    return ok;
+}
+
+#endif // ENABLE_GVAWATERMARK_GPU

--- a/src/monolithic/gst/elements/gvawatermark/renderer/gpu/renderer_gpu.cpp
+++ b/src/monolithic/gst/elements/gvawatermark/renderer/gpu/renderer_gpu.cpp
@@ -1439,6 +1439,13 @@ bool RendererGPU::get_planes(VASurfaceID surface, cl_mem planes[2]) {
     _plane_cache.emplace(surface, imported);
     planes[0] = imported[0];
     planes[1] = imported[1];
+
+    /* The pool is fixed, so this should stop growing within the first few
+     * frames and then never again. A count that keeps climbing over a long run
+     * means surfaces are not being recycled and the imports are a leak, which
+     * is otherwise only visible as GPU memory growth. */
+    GST_DEBUG("gvawatermark GPU renderer: imported surface %u, %zu in the plane cache",
+              static_cast<unsigned>(surface), _plane_cache.size());
     return true;
 }
 

--- a/src/monolithic/gst/elements/gvawatermark/renderer/gpu/renderer_gpu.h
+++ b/src/monolithic/gst/elements/gvawatermark/renderer/gpu/renderer_gpu.h
@@ -1,0 +1,349 @@
+/*******************************************************************************
+ * Copyright (C) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#pragma once
+
+#ifdef ENABLE_GVAWATERMARK_GPU
+
+#include "color_converter.h"
+#include "render_prim.h"
+#include "renderer_gpu_raster.h"
+
+#include <va/va.h>
+
+#ifndef CL_TARGET_OPENCL_VERSION
+#define CL_TARGET_OPENCL_VERSION 300
+#endif
+#include <CL/cl.h>
+#include <CL/cl_va_api_media_sharing_intel.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+/**
+ * Rasterizes watermark primitives straight into the planes of a VA surface
+ * with OpenCL.
+ *
+ * The planes are imported zero-copy through cl_intel_va_api_media_sharing, so
+ * there is no NV12->BGR->NV12 round trip and no full-frame overlay: the cost is
+ * proportional to the pixels the primitives actually cover, not to the frame
+ * area. Text is still rasterized on the CPU (Hershey vector fonts are not worth
+ * reimplementing on the GPU) and uploaded as a small coverage mask.
+ *
+ * Pixel semantics are matched against RendererNV12, the CPU renderer the same
+ * format would have used, because the CPU output is the golden reference.
+ *
+ * NV12 only. Every other format keeps using the CPU renderer.
+ */
+class RendererGPU {
+  public:
+    /* Returns nullptr when this platform cannot support the path (no
+     * cl_intel_va_api_media_sharing, no device for the VADisplay, kernels fail
+     * to build). The caller must then use the CPU renderer. */
+    static std::unique_ptr<RendererGPU> create(VADisplay display, int width, int height,
+                                               std::shared_ptr<ColorConverter> color_converter);
+
+    ~RendererGPU();
+
+    RendererGPU(const RendererGPU &) = delete;
+    RendererGPU &operator=(const RendererGPU &) = delete;
+
+    /* Draws `prims` into `surface`. Returns false without touching the surface
+     * when the primitive list contains something this renderer cannot draw yet;
+     * the caller must then fall back to the CPU renderer for the frame. */
+    bool draw_surface(VASurfaceID surface, std::vector<render::Prim> prims);
+
+    /* Human readable reason for the last false returned by draw_surface(). */
+    const std::string &last_unsupported() const {
+        return _last_unsupported;
+    }
+
+  private:
+    /* Mirrors `wm_prim` in renderer_gpu_kernels.h. */
+    struct Prim {
+        cl_int4 a;
+        cl_int4 b;
+        cl_float4 color;
+    };
+    static_assert(sizeof(Prim) == 48, "wm_prim layout must match the OpenCL struct");
+
+    /* One entry of the CPU-rasterized coverage atlas. Text bitmaps are stable
+     * across frames ("bottle 86%" typically survives dozens of frames), so
+     * entries are keyed on the full set of rasterization parameters and reused,
+     * which is what keeps the per-ROI cost down. */
+    struct AtlasEntry {
+        size_t offset;
+        int width;
+        int height;
+        int origin_x; // add to text.org to get the blit destination
+        int origin_y;
+    };
+
+    /* Process-wide, per-VADisplay OpenCL context and compiled program. Sharing
+     * these across elements avoids one context and one program build per
+     * stream; command queues and kernels stay per-instance because neither is
+     * thread safe. */
+    struct SharedContext;
+
+    /* One kind of primitive, and with it one kernel. The low bit is the plane,
+     * so `id & 1` selects it; plane 0 is Y and plane 1 is UV, and the two are
+     * separate images and are scheduled independently. */
+    enum BatchId {
+        SPAN_P0, // rasterized lines, polygons and circles, as per-row runs
+        SPAN_P1,
+        OUTLINE_P0, // axis-aligned rectangle outlines
+        OUTLINE_P1,
+        FILL_P0, // filled rectangles (text backgrounds)
+        FILL_P1,
+        MASK_P0, // CPU-rasterized coverage masks (text)
+        MASK_P1,
+        BLUR_P0, // Gaussian blur of one rectangle, two dispatches
+        BLUR_P1,
+        BLEND_P0, // half-and-half blend of a segmentation mask, two dispatches
+        BLEND_P1,
+        BATCH_COUNT
+    };
+
+    /* One clEnqueueNDRangeKernel: primitives of a single kind whose pixels may
+     * be written in any order.
+     *
+     * Getting this right is the whole reason the flattening is not just "one
+     * batch per kind". Work items of one NDRange are unordered relative to each
+     * other, so two records covering a pixel with *different* colours race, and
+     * the frame is not even reproducible run to run. Overlapping draws therefore
+     * have to be split across dispatches: the queue is in-order, so a later
+     * group reliably paints over an earlier one, which is exactly the CPU
+     * renderer's painter semantics.
+     *
+     * A group boundary is only forced where a primitive actually overlaps a
+     * differently-coloured predecessor, so the ordinary frame - detections that
+     * do not touch - still costs one dispatch per kind, as before. */
+    struct Group {
+        /* Conflict-test record for one primitive: its bounding box, inclusive,
+         * plus what it paints there. `any_color` marks a record that has to be
+         * treated as conflicting whatever the other colour is, which is what the
+         * span groups use: they hold runs of many different colours under a
+         * single box. */
+        struct Box {
+            int x0, y0, x1, y1;
+            cl_float4 color;
+            bool any_color;
+        };
+
+        BatchId id = SPAN_P0;
+        std::vector<Prim> prims;
+        std::vector<Box> boxes;
+        int max_w = 0; // global work size, dimension 0
+        int max_h = 0; // global work size, dimension 1
+        int base = 0;  // offset into the concatenated device array
+        /* Blur and blend hold exactly one primitive and go out as a pair of
+         * dispatches sharing one scratch buffer, so nothing may be merged into
+         * them and they are never reused as a scheduling target. */
+        bool exclusive = false;
+    };
+
+    RendererGPU(std::shared_ptr<SharedContext> shared, std::shared_ptr<ColorConverter> color_converter, int width,
+                int height);
+
+    bool init();
+
+    /* Dimensions of one plane; plane 1 is the half-resolution chroma. */
+    int plane_width(int plane) const {
+        return plane == 0 ? _width : _width / 2;
+    }
+    int plane_height(int plane) const {
+        return plane == 0 ? _height : _height / 2;
+    }
+
+    /* Per-frame primitive flattening. Returns false on an unsupported prim. */
+    bool flatten(std::vector<render::Prim> &prims);
+    bool flatten_rect(const render::Rect &rect);
+    bool flatten_text(const render::Text &text);
+    bool flatten_line(const render::Line &line);
+    bool flatten_circle(const render::Circle &circle);
+    bool flatten_polygon(const render::Polygon &polygon);
+    bool flatten_blur(const render::Blur &blur);
+    bool flatten_instance_mask(const render::InstanceSegmantationMask &mask);
+
+    /* Picks the group this primitive belongs in and records its conflict box:
+     * the first group running kernel `id` that comes after every group already
+     * holding a conflicting primitive, or a fresh group at the end. Since
+     * primitives arrive in the CPU renderer's draw order, this places each one
+     * after everything it may not be allowed to race with, and nothing that
+     * conflicts with it can ever be scheduled later. */
+    Group &group_for(BatchId id, int x0, int y0, int x1, int y1, const cl_float4 &color, bool any_color);
+    /* Appends a group nothing else may join. Read-modify-write primitives need
+     * this: they conflict with any overlapping neighbour whatever its colour,
+     * and their two dispatches have to stay adjacent in the queue. */
+    Group &exclusive_group(BatchId id, int x0, int y0, int x1, int y1);
+
+    void add_outline(BatchId id, int x0, int y0, int x1, int y1, int k, const cl_float4 &color);
+    void add_fill(BatchId id, int x0, int y0, int x1, int y1, const cl_float4 &color);
+    void add_mask(BatchId id, const AtlasEntry &entry, int dst_x, int dst_y, const cl_float4 &color);
+    /* Coalesces a rasterized pixel set into per-row runs and inserts them into
+     * the pending per-row span lists in painter's order. Returns false once the
+     * frame has produced more records than the per-frame budget, so a
+     * pathological polygon falls back to the CPU instead of allocating without
+     * bound. */
+    bool add_raster(BatchId span_id, const renderer_gpu::Raster &raster, const cl_float4 &color);
+
+    /* One painted interval [x1, x2] of one plane row. */
+    struct SpanRec {
+        int x1, x2;
+        cl_float4 color;
+    };
+    /* Inserts [a, b] over whatever `row` already holds: the new interval wins,
+     * so overlapped entries are trimmed or dropped. Keeps every entry of a row
+     * disjoint from every other, which is what lets an arbitrary pile of
+     * differently-coloured shapes go out as a single dispatch. */
+    void insert_span(std::vector<SpanRec> &row, int a, int b, const cl_float4 &color);
+    /* Moves the pending runs of one plane into a group, so that whatever is
+     * scheduled next is ordered against them. Runs stay pending as long as
+     * possible, because a pending run can still be clipped by a later shape and
+     * a whole pile of shapes then costs a single dispatch. */
+    void flush_spans(int plane);
+    /* Flushes only if the pending runs are under the given box, which is the
+     * only case where the next primitive has to be ordered against them. */
+    void flush_spans_overlapping(int plane, int x0, int y0, int x1, int y1);
+
+    /* The two forms of a Gaussian kernel of a given length: the float
+     * coefficients cv::getGaussianKernel returns, and, when OpenCV would accept
+     * them as bit-exact, the same coefficients scaled by 256 and rounded. Which
+     * pair sepFilter2D uses is decided per blur, because it takes the row and
+     * the column kernel together. */
+    struct CoeffEntry {
+        size_t float_offset;
+        size_t int_offset;
+        bool int_valid;
+    };
+    const CoeffEntry *gaussian_coeffs(int ksize);
+
+    /* In the integer fixed-point regime OpenCV's column filter rounds two
+     * different ways within a single row: SymmColumnVec_32s8u accumulates in
+     * float and rounds half to even, and whatever it leaves at the end of the
+     * row falls to the scalar (s + 1<<15) >> 16, which rounds half up. The two
+     * disagree on exact .5 ties, which a hard-edged rectangle under a blur hits
+     * readily, so the handover column has to be reproduced. It is
+     * VTraits<v_uint8>::vlanes() dependent, i.e. it varies with the SIMD width
+     * OpenCV dispatched to, so it is measured rather than assumed. */
+    void calibrate_blur_rounding();
+    /* Elements (not pixels) of a row of `n` that the vectorized path takes. */
+    int blur_vector_elements(int n) const;
+
+    /* One rectangle of one plane, blurred in place. `cn` is the plane's channel
+     * count, which the rounding handover is expressed in. */
+    void add_blur(BatchId id, const cv::Rect &rect, int cn, int kw, int kh, const CoeffEntry &cx, const CoeffEntry &cy,
+                  bool integer_regime);
+    /* One rectangle of one plane, blended half-and-half with `color` wherever
+     * `bitmap` (CV_8UC1, rectangle sized) is non-zero. */
+    bool add_blend(BatchId id, const cv::Rect &rect, const cv::Mat &bitmap, const cl_float4 &color);
+
+    const AtlasEntry *rasterize_text(const std::string &text, int fonttype, double fontscale, int thick);
+
+    bool sync_atlas();
+    bool sync_coeffs();
+    bool sync_blob();
+    bool sync_scratch();
+    bool sync_prims();
+    bool get_planes(VASurfaceID surface, cl_mem planes[2]);
+    bool enqueue(const Group &group, cl_mem image, int image_w, int image_h);
+
+    static cl_float4 plane_color_y(const cv::Scalar &yuv);
+    static cl_float4 plane_color_uv(const cv::Scalar &yuv);
+
+    std::shared_ptr<SharedContext> _shared;
+    std::shared_ptr<ColorConverter> _color_converter;
+
+    const int _width;
+    const int _height;
+
+    cl_command_queue _queue = nullptr;
+    cl_kernel _k_outlines = nullptr;
+    cl_kernel _k_fills = nullptr;
+    cl_kernel _k_masks = nullptr;
+    cl_kernel _k_spans = nullptr;
+    cl_kernel _k_blur_h = nullptr;
+    cl_kernel _k_blur_v = nullptr;
+    cl_kernel _k_blend_gather = nullptr;
+    cl_kernel _k_blend_scatter = nullptr;
+
+    /* Scratch for the CPU rasterizers and for the run coalescing in
+     * add_raster(), reused across prims and frames so the per-frame path does
+     * not allocate. */
+    struct Span {
+        int y, x1, x2;
+    };
+    renderer_gpu::Raster _raster;
+    std::vector<Span> _merge;
+
+    /* Painter's-order accumulator for the rasterized shapes, one entry per plane
+     * row, indexed [plane][row]. Sized once and only cleared per frame, so the
+     * row vectors keep their capacity. _span_pending counts the entries
+     * currently held, which is what lets the reset and the flush walk be skipped
+     * on the ordinary frame that draws no shapes; _span_box is their union,
+     * used to decide whether a later primitive lands on top of them. */
+    std::array<std::vector<std::vector<SpanRec>>, 2> _span_rows;
+    std::array<size_t, 2> _span_pending = {0, 0};
+    std::array<std::array<int, 4>, 2> _span_box{};
+    size_t _span_records = 0; // pending plus already flushed, for the budget
+
+    /* VA surfaces cycle through a fixed pool, so the imported plane images are
+     * cached per surface id instead of reimported every frame. */
+    std::unordered_map<VASurfaceID, std::array<cl_mem, 2>> _plane_cache;
+
+    /* Dispatch schedule, per plane, in order. Groups are reused across frames
+     * for their storage; _group_count says how many of them the current frame
+     * actually uses. */
+    std::array<std::vector<Group>, 2> _groups;
+    std::array<size_t, 2> _group_count = {0, 0};
+    std::vector<Prim> _prims; // all groups concatenated, as uploaded
+    cl_mem _prim_buffer = nullptr;
+    size_t _prim_buffer_capacity = 0;
+
+    std::unordered_map<std::string, AtlasEntry> _atlas_index;
+    std::vector<uint8_t> _atlas_host;
+    cl_mem _atlas_buffer = nullptr;
+    size_t _atlas_buffer_capacity = 0;
+    size_t _atlas_uploaded = 0;
+
+    /* Gaussian coefficients, keyed on kernel length. Only a handful of lengths
+     * occur in a stream and they recur frame after frame, so this is populated
+     * once and then only read. */
+    std::unordered_map<int, CoeffEntry> _coeff_index;
+    std::vector<float> _coeff_host;
+    cl_mem _coeff_buffer = nullptr;
+    size_t _coeff_buffer_capacity = 0;
+    size_t _coeff_uploaded = 0;
+
+    /* Measured by calibrate_blur_rounding(): the number of uchars OpenCV's
+     * vectorized column filter consumes per step, or 0 if this build has no
+     * vector path at all. */
+    int _blur_vec_lanes = 0;
+
+    /* Segmentation coverage bitmaps. Unlike glyphs these are different every
+     * frame, so they get their own buffer and are rebuilt from scratch rather
+     * than evicting the cached text. */
+    std::vector<uint8_t> _blob_host;
+    cl_mem _blob_buffer = nullptr;
+    size_t _blob_buffer_capacity = 0;
+
+    /* Staging for the read-modify-write primitives: the blur's row-pass output
+     * and the blend's read-back destination. Each of them is a pair of adjacent
+     * dispatches on an in-order queue, so a single buffer sized to the largest
+     * of them serves the whole frame. One element is the kernels' `wm_vec`, a
+     * float2, which is as wide as either NV12 plane has channels to carry. */
+    cl_mem _scratch_buffer = nullptr;
+    size_t _scratch_buffer_capacity = 0; // in wm_vec elements
+    size_t _scratch_needed = 0;
+
+    std::string _last_unsupported;
+};
+
+#endif // ENABLE_GVAWATERMARK_GPU

--- a/src/monolithic/gst/elements/gvawatermark/renderer/gpu/renderer_gpu_kernels.h
+++ b/src/monolithic/gst/elements/gvawatermark/renderer/gpu/renderer_gpu_kernels.h
@@ -1,0 +1,318 @@
+/*******************************************************************************
+ * Copyright (C) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#pragma once
+
+// OpenCL C sources for the plane-native watermark renderer.
+//
+// Every kernel takes a single plane as a `__write_only image2d_t` plus that
+// plane's dimensions, and a `wm_prim` array shared by all kernels. The host
+// packs plane-specific geometry and an already-converted, already-normalized
+// colour into `wm_prim`, so the kernels never do colour conversion and never
+// need to know which plane they are writing:
+//
+//   NV12 Y  plane -> image is CL_R    / CL_UNORM_INT8, colour = (Y, 0, 0, 0)
+//   NV12 UV plane -> image is CL_RG   / CL_UNORM_INT8, colour = (U, V, 0, 0)
+//   packed 4-byte -> image is CL_RGBA / CL_UNORM_INT8, colour = the four bytes
+//                    the CPU renderer would write, in memory order
+//
+// The images come from clCreateFromVA_APIMediaSurfaceINTEL and are UNORM, so
+// all writes go through write_imagef with values normalized to [0, 1].
+// write_imageui compiles but silently writes zeros.
+
+namespace renderer_gpu {
+
+// clang-format off
+static const char *const KERNELS = R"CLC(
+
+typedef struct {
+    int4   a;      // outline/fill: x0, y0, x1, y1 (inclusive)
+                   // span:         x1, x2 (inclusive), y, unused
+                   // mask:         dst_x, dst_y, w, h
+                   // blur/blend:   x, y, w, h
+    int4   b;      // outline: band half-width k
+                   // mask:    atlas byte offset, atlas row stride
+                   // blur:    kernel width, kernel height, kx offset, ky offset
+                   // blend:   blob byte offset, blob row stride
+    float4 color;  // plane-packed, normalized to [0, 1]
+                   // blur:    x != 0 selects the integer fixed-point regime,
+                   //          y is the column at which that regime hands over
+                   //          from round-half-even to round-half-up
+} wm_prim;
+
+__constant sampler_t WM_SAMPLER = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+// The channels a read-modify-write kernel has to carry through its scratch
+// buffer: two, which covers either NV12 plane. WM_LOAD narrows what
+// read_imagef returned, WM_STORE widens it back for write_imagef.
+typedef float2 wm_vec;
+#define WM_ZERO     ((float2)(0.f, 0.f))
+#define WM_LOAD(v)  ((float2)((v).x, (v).y))
+#define WM_STORE(s) ((float4)((s).x, (s).y, 0.f, 0.f))
+
+// cv::borderInterpolate(p, len, BORDER_REFLECT_101). Loops, because a
+// primitive's Gaussian kernel can be wider than the plane.
+inline int wm_reflect101(int p, int len) {
+    if (len == 1)
+        return 0;
+    while (p < 0 || p >= len)
+        p = p < 0 ? -p : 2 * len - 2 - p;
+    return p;
+}
+
+// Rectangle outline, reproducing cv::rectangle(LINE_8, thickness > 0).
+//
+// OpenCV draws the four edges as thick lines and caps every line end with a
+// filled disc (ThickLine -> FillConvexPoly + Circle, drawing.cpp), so the
+// painted set is the union of
+//   - four axis-aligned bands, each centred on its edge and extending +-k
+//     pixels across, spanning only between the corners, and
+//   - four filled discs of radius k centred on the corners.
+// The discs are what round off the outer corner notches; a plain band union
+// leaves them empty and a square corner extension overfills them. This model
+// was checked pixel-exact against cv::rectangle for thickness 1..10 over every
+// corner parity (/tmp/wm_poc/corner2.cpp, 6.4M pixels, 0 mismatches).
+//
+// Work item = (position along the edge / disc column, offset across the band /
+// disc row, prim * 8 + sub), sub 0..3 = edges, sub 4..7 = corner discs.
+__kernel void wm_outlines(__write_only image2d_t img, int iw, int ih,
+                          __global const wm_prim *prims, int base) {
+    const int id2 = get_global_id(2);
+    const wm_prim p = prims[base + (id2 >> 3)];
+    const int sub = id2 & 7;
+
+    const int k = p.b.x;
+    const int t = get_global_id(1);
+    if (t > 2 * k)
+        return;
+    const int off = t - k;
+
+    const int i = get_global_id(0);
+    int x, y;
+    if (sub >= 4) {                                 // corner disc
+        const int d = i - k;
+        if (i > 2 * k || d * d + off * off > k * k)
+            return;
+        x = ((sub & 1) ? p.a.z : p.a.x) + d;
+        y = ((sub & 2) ? p.a.w : p.a.y) + off;
+    } else if (sub < 2) {                           // top / bottom band
+        x = p.a.x + i;
+        if (x > p.a.z)
+            return;
+        y = (sub == 0 ? p.a.y : p.a.w) + off;
+    } else {                                        // left / right band
+        y = p.a.y + i;
+        if (y > p.a.w)
+            return;
+        x = (sub == 2 ? p.a.x : p.a.z) + off;
+    }
+
+    if (x < 0 || y < 0 || x >= iw || y >= ih)
+        return;
+    write_imagef(img, (int2)(x, y), p.color);
+}
+
+// Filled rectangle, reproducing cv::rectangle(cv::FILLED): both corners
+// inclusive.
+__kernel void wm_fills(__write_only image2d_t img, int iw, int ih,
+                       __global const wm_prim *prims, int base) {
+    const wm_prim p = prims[base + get_global_id(2)];
+    const int x = p.a.x + get_global_id(0);
+    const int y = p.a.y + get_global_id(1);
+    if (x > p.a.z || y > p.a.w)
+        return;
+    if (x < 0 || y < 0 || x >= iw || y >= ih)
+        return;
+    write_imagef(img, (int2)(x, y), p.color);
+}
+
+// One horizontal run [a.x, a.y] on row a.z. Lines, polygons and filled circles
+// all reduce to runs: the CPU ports of OpenCV's FillConvexPoly / Line2 /
+// LineIterator in renderer_gpu_raster.h decide *which* pixels OpenCV would
+// paint, add_raster() coalesces them per row, and this kernel does the writing.
+// Because every shape lands in one batch, the device-side draw order is the CPU
+// renderer's prim order.
+__kernel void wm_spans(__write_only image2d_t img, int iw, int ih,
+                       __global const wm_prim *prims, int base) {
+    const wm_prim p = prims[base + get_global_id(2)];
+    const int x = p.a.x + (int)get_global_id(0);
+    if (x > p.a.y)
+        return;
+    const int y = p.a.z;
+    if (x < 0 || y < 0 || x >= iw || y >= ih)
+        return;
+    write_imagef(img, (int2)(x, y), p.color);
+}
+
+// Blit an 8-bit coverage mask (text rasterized on the CPU, segmentation
+// masks thresholded on the CPU) from a linear atlas buffer. Non-zero
+// coverage writes the flat prim colour, matching cv::putText with LINE_8.
+__kernel void wm_masks(__write_only image2d_t img, int iw, int ih,
+                       __global const uchar *atlas,
+                       __global const wm_prim *prims, int base) {
+    const wm_prim p = prims[base + get_global_id(2)];
+    const int ix = get_global_id(0);
+    const int iy = get_global_id(1);
+    if (ix >= p.a.z || iy >= p.a.w)
+        return;
+    if (atlas[p.b.x + iy * p.b.y + ix] == 0)
+        return;
+
+    const int x = p.a.x + ix;
+    const int y = p.a.y + iy;
+    if (x < 0 || y < 0 || x >= iw || y >= ih)
+        return;
+    write_imagef(img, (int2)(x, y), p.color);
+}
+
+// Gaussian blur of one rectangle, reproducing cv::GaussianBlur() applied
+// in-place to a submatrix with BORDER_DEFAULT - which is what
+// RendererNV12::blur_rectangle does.
+//
+// Three properties of that call have to be reproduced and none of them is
+// obvious:
+//
+//  - The bit-exact ufixedpoint16 path is skipped, because it needs
+//    BORDER_ISOLATED or a non-submatrix (smooth.dispatch.cpp). What actually
+//    runs is the generic sepFilter2D.
+//  - The taps therefore read the plane's *real* pixels outside the rectangle,
+//    and only reflect (BORDER_REFLECT_101) at the plane boundary.
+//  - Which arithmetic sepFilter2D uses depends on the kernel: if every
+//    coefficient times 256 is integral, it runs an integer fixed-point pass
+//    (coefficients rounded to that integer, output (s + 1<<15) >> 16),
+//    otherwise a float pass (output cvRound(s)). The host decides and passes
+//    the answer in color.x. One float kernel serves both, because every
+//    intermediate of the integer regime - row sums up to 256*255, column sums
+//    up to 256*65280 - is exactly representable in binary32.
+//
+// Separable, so the cost is O(kw + kh) per pixel rather than O(kw * kh); split
+// across two dispatches through a scratch buffer because a kernel may not both
+// read and write one image (and this device has no __read_write image2d_t
+// anyway). The row pass covers kh - 1 extra rows, which are the ones the column
+// pass reaches above and below the rectangle.
+//
+// Every plane goes through the same code: the row pass reads whatever channels
+// wm_vec is wide, so a CL_R plane simply carries a zero in .y.
+__kernel void wm_blur_h(__read_only image2d_t img, int iw, int ih,
+                        __global wm_vec *scratch,
+                        __global const float *coeffs,
+                        __global const wm_prim *prims, int base) {
+    const wm_prim p = prims[base];
+    const int rw = p.a.z, rh = p.a.w;
+    const int kw = p.b.x, kh = p.b.y;
+
+    const int ix = get_global_id(0);
+    const int iy = get_global_id(1);
+    if (ix >= rw || iy >= rh + kh - 1)
+        return;
+
+    const int sy = wm_reflect101(p.a.y + iy - (kh >> 1), ih);
+    const int x0 = p.a.x + ix - (kw >> 1);
+    __global const float *kx = coeffs + p.b.z;
+
+    // OpenCV's generic RowFilter accumulates straight through the taps.
+    wm_vec s = WM_ZERO;
+    for (int k = 0; k < kw; ++k) {
+        const float4 v = read_imagef(img, WM_SAMPLER, (int2)(wm_reflect101(x0 + k, iw), sy));
+        s += kx[k] * round(WM_LOAD(v) * 255.f);
+    }
+    scratch[iy * rw + ix] = s;
+}
+
+__kernel void wm_blur_v(__write_only image2d_t img, int iw, int ih,
+                        __global const wm_vec *scratch,
+                        __global const float *coeffs,
+                        __global const wm_prim *prims, int base) {
+    const wm_prim p = prims[base];
+    const int rw = p.a.z, rh = p.a.w;
+    const int ay = p.b.y >> 1;
+
+    const int ix = get_global_id(0);
+    const int iy = get_global_id(1);
+    if (ix >= rw || iy >= rh)
+        return;
+
+    // OpenCV's SymmColumnFilter pairs the taps around the centre one.
+    __global const float *ky = coeffs + p.b.w + ay;
+    __global const wm_vec *col = scratch + (iy + ay) * rw + ix;
+    wm_vec s = ky[0] * col[0];
+    for (int k = 1; k <= ay; ++k)
+        s += ky[k] * (col[k * rw] + col[-k * rw]);
+
+    if (p.color.x != 0.f) {
+        // Integer fixed-point regime. OpenCV rounds a row of it two ways:
+        // SymmColumnVec_32s8u divides by 1<<16 in float and rounds half to
+        // even, and the elements it leaves at the end of the row go through the
+        // scalar FixedPtCastEx, (s + 1<<15) >> 16, which rounds half up. Ties
+        // are common right under a hard-edged rectangle, so the handover
+        // column, measured host side, has to be honoured.
+        s = ix < (int)p.color.y ? rint(s * (1.f / 65536.f)) : floor((s + 32768.f) * (1.f / 65536.f));
+    } else {
+        // Float regime: saturate_cast<uchar> either way, so one rounding.
+        s = rint(s);
+    }
+    s = clamp(s, 0.f, 255.f) * (1.f / 255.f);
+
+    const int x = p.a.x + ix, y = p.a.y + iy;
+    if (x < 0 || y < 0 || x >= iw || y >= ih)
+        return;
+    write_imagef(img, (int2)(x, y), WM_STORE(s));
+}
+
+// Half-and-half blend of a flat colour under an 8-bit coverage bitmap,
+// reproducing the addWeighted(0.5) + copyTo(mask) tail of
+// RendererNV12::draw_instance_mask.
+//
+// Split in two for the same reason the blur is: the blend reads the pixel it
+// then overwrites. The queue is in-order, so every gather has landed before the
+// first scatter runs.
+__kernel void wm_blend_gather(__read_only image2d_t img, int iw, int ih,
+                              __global wm_vec *scratch,
+                              __global const uchar *blob,
+                              __global const wm_prim *prims, int base) {
+    const wm_prim p = prims[base];
+    const int ix = get_global_id(0);
+    const int iy = get_global_id(1);
+    if (ix >= p.a.z || iy >= p.a.w)
+        return;
+    if (blob[p.b.x + iy * p.b.y + ix] == 0)
+        return;
+
+    const int x = p.a.x + ix, y = p.a.y + iy;
+    if (x < 0 || y < 0 || x >= iw || y >= ih)
+        return;
+
+    const float4 v = read_imagef(img, WM_SAMPLER, (int2)(x, y));
+    const wm_vec src = round(WM_LOAD(v) * 255.f);
+    const wm_vec col = round(WM_LOAD(p.color) * 255.f);
+    const wm_vec out = clamp(rint(col * 0.5f + src * 0.5f), 0.f, 255.f);
+    scratch[iy * p.a.z + ix] = out * (1.f / 255.f);
+}
+
+__kernel void wm_blend_scatter(__write_only image2d_t img, int iw, int ih,
+                               __global const wm_vec *scratch,
+                               __global const uchar *blob,
+                               __global const wm_prim *prims, int base) {
+    const wm_prim p = prims[base];
+    const int ix = get_global_id(0);
+    const int iy = get_global_id(1);
+    if (ix >= p.a.z || iy >= p.a.w)
+        return;
+    if (blob[p.b.x + iy * p.b.y + ix] == 0)
+        return;
+
+    const int x = p.a.x + ix, y = p.a.y + iy;
+    if (x < 0 || y < 0 || x >= iw || y >= ih)
+        return;
+
+    const wm_vec v = scratch[iy * p.a.z + ix];
+    write_imagef(img, (int2)(x, y), WM_STORE(v));
+}
+
+)CLC";
+// clang-format on
+
+} // namespace renderer_gpu

--- a/src/monolithic/gst/elements/gvawatermark/renderer/gpu/renderer_gpu_raster.h
+++ b/src/monolithic/gst/elements/gvawatermark/renderer/gpu/renderer_gpu_raster.h
@@ -155,8 +155,7 @@ inline void line2(P2L pt1, P2L pt2, int w, int h, Raster &out) {
     };
     /* Line2 emits the far endpoint before walking, so a zero-length run still
      * paints one pixel. */
-    put(static_cast<int>((pt2.x + (XY_ONE >> 1)) >> XY_SHIFT),
-        static_cast<int>((pt2.y + (XY_ONE >> 1)) >> XY_SHIFT));
+    put(static_cast<int>((pt2.x + (XY_ONE >> 1)) >> XY_SHIFT), static_cast<int>((pt2.y + (XY_ONE >> 1)) >> XY_SHIFT));
     if (ax > ay) {
         pt1.x >>= XY_SHIFT;
         for (; ecount >= 0; --ecount, ++pt1.x, pt1.y += y_step)
@@ -349,8 +348,8 @@ inline void thick_line(cv::Point pt1, cv::Point pt2, int thickness, int caps, in
     /* drawing.cpp:1650 - a thick line with an endpoint outside the frame is
      * first clipped to a rect grown by `thickness`, which moves the point the
      * cap disc is centred on. Skipping this costs a pixel at the frame border. */
-    if (thickness > 1 && (p0.x < 0 || p0.x >= w || p0.y < 0 || p0.y >= h || p1.x < 0 || p1.x >= w || p1.y < 0 ||
-                          p1.y >= h)) {
+    if (thickness > 1 &&
+        (p0.x < 0 || p0.x >= w || p0.y < 0 || p0.y >= h || p1.x < 0 || p1.x >= w || p1.y < 0 || p1.y >= h)) {
         const long long m = thickness;
         p0.x += m;
         p0.y += m;
@@ -387,10 +386,8 @@ inline void thick_line(cv::Point pt1, cv::Point pt2, int thickness, int caps, in
     if (std::fabs(r) > DBL_EPSILON) {
         r = (th + odd_thickness * XY_ONE * 0.5) / std::sqrt(r);
         const long long dpx = cvRound(ddy * r), dpy = cvRound(ddx * r);
-        const P2L quad[4] = {{p0.x + dpx, p0.y + dpy},
-                             {p0.x - dpx, p0.y - dpy},
-                             {p1.x - dpx, p1.y - dpy},
-                             {p1.x + dpx, p1.y + dpy}};
+        const P2L quad[4] = {
+            {p0.x + dpx, p0.y + dpy}, {p0.x - dpx, p0.y - dpy}, {p1.x - dpx, p1.y - dpy}, {p1.x + dpx, p1.y + dpy}};
         fill_convex_poly(quad, 4, w, h, out);
     }
 

--- a/src/monolithic/gst/elements/gvawatermark/renderer/gpu/renderer_gpu_raster.h
+++ b/src/monolithic/gst/elements/gvawatermark/renderer/gpu/renderer_gpu_raster.h
@@ -1,0 +1,409 @@
+/*******************************************************************************
+ * Copyright (C) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#pragma once
+
+#ifdef ENABLE_GVAWATERMARK_GPU
+
+#include <opencv2/opencv.hpp>
+
+#include <algorithm>
+#include <cfloat>
+#include <cmath>
+#include <vector>
+
+/**
+ * CPU rasterizers that emit the exact pixel set OpenCV would paint for lines,
+ * polygons and filled circles, expressed as horizontal runs plus single pixels.
+ *
+ * Why the CPU: OpenCV rasterizes thick lines as FillConvexPoly() of a quad plus
+ * a disc at the capped ends, and FillConvexPoly() is a serial fixed-point
+ * scanline walk whose per-row state depends on the previous row. A plain
+ * convex-quad half-plane test in a kernel is *not* equivalent - it misses about
+ * a dozen pixels per line, because FillConvexPoly() also strokes the polygon
+ * outline with Line2() on top of the span fill. Rather than approximate it,
+ * these functions port OpenCV's own arithmetic and hand the GPU a list of runs;
+ * the CPU cost is then proportional to the perimeter and the row count, and the
+ * GPU still does all of the area writes.
+ *
+ * The ports are pixel-exact against OpenCV 4.13 (the version DL Streamer links)
+ * over 93355 cases with zero mismatching pixels: cv::line for thickness 1..12 x
+ * 120 angles x 8 lengths x 7 offsets including endpoints outside the frame,
+ * cv::drawContours for 1..10-gons with vertices outside the frame,
+ * cv::circle(FILLED) for radius 0..200 with centres outside the frame, and
+ * cv::line on a CV_8UC2 non-square plane (the NV12 UV geometry). The probe is
+ * /tmp/wm_poc/raster_test.cpp. Do not "simplify" any of the arithmetic below
+ * without re-running it - every rounding detail is load bearing.
+ *
+ * References are to opencv/modules/imgproc/src/drawing.cpp.
+ */
+namespace renderer_gpu {
+
+constexpr int XY_SHIFT = 16;
+constexpr long long XY_ONE = 1 << XY_SHIFT;
+
+struct Raster {
+    struct Run {
+        int x1, x2, y; // inclusive [x1, x2] on row y
+    };
+    std::vector<Run> runs;
+    std::vector<cv::Point> points;
+
+    void clear() {
+        runs.clear();
+        points.clear();
+    }
+    size_t size() const {
+        return runs.size() + points.size();
+    }
+};
+
+/* OpenCV's fixed-point point type, Point2l. */
+struct P2L {
+    long long x, y;
+};
+
+/* Port of cv::clipLine(Size2l, Point2l&, Point2l&), drawing.cpp:92. Note the
+ * fixed two-stage structure (clip y, then clip x) and that the second stage
+ * reads the x1 the first stage already updated - a general Liang-Barsky loop
+ * gives different results. */
+inline bool clip_line(long long w, long long h, P2L &pt1, P2L &pt2) {
+    const long long right = w - 1, bottom = h - 1;
+    if (w <= 0 || h <= 0)
+        return false;
+
+    long long &x1 = pt1.x, &y1 = pt1.y, &x2 = pt2.x, &y2 = pt2.y;
+    int c1 = (x1 < 0) + (x1 > right) * 2 + (y1 < 0) * 4 + (y1 > bottom) * 8;
+    int c2 = (x2 < 0) + (x2 > right) * 2 + (y2 < 0) * 4 + (y2 > bottom) * 8;
+
+    if ((c1 & c2) == 0 && (c1 | c2) != 0) {
+        long long a;
+        if (c1 & 12) {
+            a = c1 < 8 ? 0 : bottom;
+            x1 += static_cast<long long>(static_cast<double>(a - y1) * (x2 - x1) / (y2 - y1));
+            y1 = a;
+            c1 = (x1 < 0) + (x1 > right) * 2;
+        }
+        if (c2 & 12) {
+            a = c2 < 8 ? 0 : bottom;
+            x2 += static_cast<long long>(static_cast<double>(a - y2) * (x2 - x1) / (y2 - y1));
+            y2 = a;
+            c2 = (x2 < 0) + (x2 > right) * 2;
+        }
+        if ((c1 & c2) == 0 && (c1 | c2) != 0) {
+            if (c1) {
+                a = c1 == 1 ? 0 : right;
+                y1 += static_cast<long long>(static_cast<double>(a - x1) * (y2 - y1) / (x2 - x1));
+                x1 = a;
+                c1 = 0;
+            }
+            if (c2) {
+                a = c2 == 1 ? 0 : right;
+                y2 += static_cast<long long>(static_cast<double>(a - x2) * (y2 - y1) / (x2 - x1));
+                x2 = a;
+                c2 = 0;
+            }
+        }
+    }
+    return (c1 | c2) == 0;
+}
+
+/* Port of the single-channel branch of Line2(), drawing.cpp:634 - the
+ * fixed-point DDA used to stroke a polygon edge. */
+inline void line2(P2L pt1, P2L pt2, int w, int h, Raster &out) {
+    if (!clip_line(static_cast<long long>(w) << XY_SHIFT, static_cast<long long>(h) << XY_SHIFT, pt1, pt2))
+        return;
+
+    long long dx = pt2.x - pt1.x, dy = pt2.y - pt1.y;
+    const long long j = dx < 0 ? -1 : 0, ax = (dx ^ j) - j;
+    const long long i = dy < 0 ? -1 : 0, ay = (dy ^ i) - i;
+    long long x_step, y_step;
+    int ecount;
+
+    if (ax > ay) {
+        dy = (dy ^ j) - j;
+        pt1.x ^= pt2.x & j;
+        pt2.x ^= pt1.x & j;
+        pt1.x ^= pt2.x & j;
+        pt1.y ^= pt2.y & j;
+        pt2.y ^= pt1.y & j;
+        pt1.y ^= pt2.y & j;
+        x_step = XY_ONE;
+        y_step = dy * (1 << XY_SHIFT) / (ax | 1);
+        ecount = static_cast<int>((pt2.x - pt1.x) >> XY_SHIFT);
+    } else {
+        dx = (dx ^ i) - i;
+        pt1.x ^= pt2.x & i;
+        pt2.x ^= pt1.x & i;
+        pt1.x ^= pt2.x & i;
+        pt1.y ^= pt2.y & i;
+        pt2.y ^= pt1.y & i;
+        pt1.y ^= pt2.y & i;
+        x_step = dx * (1 << XY_SHIFT) / (ay | 1);
+        y_step = XY_ONE;
+        ecount = static_cast<int>((pt2.y - pt1.y) >> XY_SHIFT);
+    }
+    pt1.x += XY_ONE >> 1;
+    pt1.y += XY_ONE >> 1;
+
+    auto put = [&](int x, int y) {
+        if (0 <= x && x < w && 0 <= y && y < h)
+            out.points.push_back({x, y});
+    };
+    /* Line2 emits the far endpoint before walking, so a zero-length run still
+     * paints one pixel. */
+    put(static_cast<int>((pt2.x + (XY_ONE >> 1)) >> XY_SHIFT),
+        static_cast<int>((pt2.y + (XY_ONE >> 1)) >> XY_SHIFT));
+    if (ax > ay) {
+        pt1.x >>= XY_SHIFT;
+        for (; ecount >= 0; --ecount, ++pt1.x, pt1.y += y_step)
+            put(static_cast<int>(pt1.x), static_cast<int>(pt1.y >> XY_SHIFT));
+    } else {
+        pt1.y >>= XY_SHIFT;
+        for (; ecount >= 0; --ecount, pt1.x += x_step, ++pt1.y)
+            put(static_cast<int>(pt1.x >> XY_SHIFT), static_cast<int>(pt1.y));
+    }
+}
+
+/* Port of FillConvexPoly(), drawing.cpp:1094, for LINE_8 and shift ==
+ * XY_SHIFT: one horizontal run per scanline plus a Line2 stroke of every edge.
+ * The strokes are not redundant - the span walk alone leaves gaps along steep
+ * edges, which is exactly why a half-plane test in a kernel does not match. */
+inline void fill_convex_poly(const P2L *v, int npts, int w, int h, Raster &out) {
+    constexpr long long delta = XY_ONE >> 1;
+    struct Edge {
+        int idx, di, ye;
+        long long x, dx;
+    } edge[2];
+
+    long long xmin = v[0].x, xmax = v[0].x, ymin = v[0].y, ymax = v[0].y;
+    int imin = 0, edges = npts;
+
+    P2L prev = v[npts - 1];
+    for (int i = 0; i < npts; i++) {
+        const P2L p = v[i];
+        if (p.y < ymin) {
+            ymin = p.y;
+            imin = i;
+        }
+        ymax = std::max(ymax, p.y);
+        xmax = std::max(xmax, p.x);
+        xmin = std::min(xmin, p.x);
+        line2(prev, p, w, h, out);
+        prev = p;
+    }
+
+    xmin = (xmin + delta) >> XY_SHIFT;
+    xmax = (xmax + delta) >> XY_SHIFT;
+    ymin = (ymin + delta) >> XY_SHIFT;
+    ymax = (ymax + delta) >> XY_SHIFT;
+    if (npts < 3 || xmax < 0 || ymax < 0 || xmin >= w || ymin >= h)
+        return;
+    ymax = std::min(ymax, static_cast<long long>(h) - 1);
+
+    int y = static_cast<int>(ymin);
+    edge[0] = {imin, 1, y, -XY_ONE, 0};
+    edge[1] = {imin, npts - 1, y, -XY_ONE, 0};
+
+    do {
+        for (int i = 0; i < 2; i++) {
+            if (y >= edge[i].ye) {
+                int idx0 = edge[i].idx, idx = idx0 + edge[i].di;
+                if (idx >= npts)
+                    idx -= npts;
+                for (; edges-- > 0;) {
+                    const int ty = static_cast<int>((v[idx].y + delta) >> XY_SHIFT);
+                    if (ty > y) {
+                        edge[i].ye = ty;
+                        edge[i].dx = ((v[idx].x - v[idx0].x) * 2 + (ty - y)) / (2 * (ty - y));
+                        edge[i].x = v[idx0].x;
+                        edge[i].idx = idx;
+                        break;
+                    }
+                    idx0 = idx;
+                    idx += edge[i].di;
+                    if (idx >= npts)
+                        idx -= npts;
+                }
+            }
+        }
+        if (edges < 0)
+            break;
+        if (y >= 0) {
+            const int left = edge[0].x > edge[1].x ? 1 : 0, right = left ^ 1;
+            int x1 = static_cast<int>((edge[left].x + delta) >> XY_SHIFT);
+            int x2 = static_cast<int>((edge[right].x + delta) >> XY_SHIFT);
+            if (x2 >= 0 && x1 < w) {
+                x1 = std::max(x1, 0);
+                x2 = std::min(x2, w - 1);
+                out.runs.push_back({x1, x2, y});
+            }
+        }
+        edge[0].x += edge[0].dx;
+        edge[1].x += edge[1].dx;
+    } while (++y <= static_cast<int>(ymax));
+}
+
+/* cv::circle(..., cv::FILLED) paints exactly dx*dx + dy*dy <= r*r. Emitting it
+ * as one run per row lets discs share the span kernel with everything else, and
+ * wastes fewer work items than dispatching over the (2r+1)^2 bounding box. */
+inline void filled_disc(int cx, int cy, int r, int w, int h, Raster &out) {
+    if (r < 0)
+        return;
+    for (int dy = -r; dy <= r; ++dy) {
+        const int y = cy + dy;
+        if (y < 0 || y >= h)
+            continue;
+        const int rest = r * r - dy * dy;
+        /* std::sqrt of an exactly representable int can round either way, so
+         * settle the boundary with integer comparisons. */
+        int dx = static_cast<int>(std::sqrt(static_cast<double>(rest)));
+        while ((dx + 1) * (dx + 1) <= rest)
+            ++dx;
+        while (dx > 0 && dx * dx > rest)
+            --dx;
+        const int x1 = std::max(cx - dx, 0), x2 = std::min(cx + dx, w - 1);
+        if (x1 <= x2)
+            out.runs.push_back({x1, x2, y});
+    }
+}
+
+/* Port of the !fill half of Circle(), drawing.cpp:1012 - the eight-way symmetric
+ * Bresenham arc that cv::circle uses for thickness 0 and 1. (Only thickness < 0
+ * fills; thickness > 1 goes to EllipseEx instead and is not ported.) The
+ * `inside` fast path is deliberately kept, because in the general path OpenCV
+ * clips each of the eight octant points independently and the two paths would
+ * otherwise be easy to get subtly out of step. */
+inline void circle_outline(int cx, int cy, int r, int w, int h, Raster &out) {
+    if (r < 0)
+        return;
+    long long err = 0, dx = r, dy = 0, plus = 1, minus = (static_cast<long long>(r) << 1) - 1;
+    const bool inside = cx >= r && cx < w - r && cy >= r && cy < h - r;
+
+    while (dx >= dy) {
+        const long long y11 = cy - dy, y12 = cy + dy, y21 = cy - dx, y22 = cy + dx;
+        const long long x11 = cx - dx, x12 = cx + dx, x21 = cx - dy, x22 = cx + dy;
+
+        const auto put = [&out](long long x, long long y) {
+            out.points.push_back(cv::Point(static_cast<int>(x), static_cast<int>(y)));
+        };
+
+        if (inside) {
+            put(x11, y11);
+            put(x11, y12);
+            put(x12, y11);
+            put(x12, y12);
+            put(x21, y21);
+            put(x21, y22);
+            put(x22, y21);
+            put(x22, y22);
+        } else if (x11 < w && x12 >= 0 && y21 < h && y22 >= 0) {
+            if (y11 >= 0 && y11 < h) {
+                if (x11 >= 0)
+                    put(x11, y11);
+                if (x12 < w)
+                    put(x12, y11);
+            }
+            if (y12 >= 0 && y12 < h) {
+                if (x11 >= 0)
+                    put(x11, y12);
+                if (x12 < w)
+                    put(x12, y12);
+            }
+            if (x21 < w && x22 >= 0) {
+                if (y21 >= 0 && y21 < h) {
+                    if (x21 >= 0)
+                        put(x21, y21);
+                    if (x22 < w)
+                        put(x22, y21);
+                }
+                if (y22 >= 0 && y22 < h) {
+                    if (x21 >= 0)
+                        put(x21, y22);
+                    if (x22 < w)
+                        put(x22, y22);
+                }
+            }
+        }
+
+        ++dy;
+        err += plus;
+        plus += 2;
+        const long long mask = (err <= 0) - 1;
+        err -= minus & mask;
+        dx += mask;
+        minus -= mask & 2;
+    }
+}
+
+/* Port of ThickLine(), drawing.cpp:1644. `caps` is OpenCV's `flags`: bit 0 caps
+ * pt1, bit 1 caps pt2. cv::line passes 3; cv::rectangle and cv::drawContours go
+ * through PolyLine and pass 2, so consecutive segments do not cap the shared
+ * vertex twice. */
+inline void thick_line(cv::Point pt1, cv::Point pt2, int thickness, int caps, int w, int h, Raster &out) {
+    P2L p0{pt1.x, pt1.y}, p1{pt2.x, pt2.y};
+
+    /* drawing.cpp:1650 - a thick line with an endpoint outside the frame is
+     * first clipped to a rect grown by `thickness`, which moves the point the
+     * cap disc is centred on. Skipping this costs a pixel at the frame border. */
+    if (thickness > 1 && (p0.x < 0 || p0.x >= w || p0.y < 0 || p0.y >= h || p1.x < 0 || p1.x >= w || p1.y < 0 ||
+                          p1.y >= h)) {
+        const long long m = thickness;
+        p0.x += m;
+        p0.y += m;
+        p1.x += m;
+        p1.y += m;
+        clip_line(w + 2 * m, h + 2 * m, p0, p1);
+        p0.x -= m;
+        p0.y -= m;
+        p1.x -= m;
+        p1.y -= m;
+    }
+
+    if (thickness <= 1) {
+        /* Thin lines take OpenCV's Bresenham path, and cv::LineIterator is the
+         * very code Line() drives, so this is exact by construction. */
+        cv::LineIterator it(cv::Size(w, h), cv::Point(static_cast<int>(p0.x), static_cast<int>(p0.y)),
+                            cv::Point(static_cast<int>(p1.x), static_cast<int>(p1.y)), 8, true);
+        for (int i = 0; i < it.count; ++i, ++it)
+            out.points.push_back(it.pos());
+        return;
+    }
+
+    p0.x <<= XY_SHIFT;
+    p0.y <<= XY_SHIFT;
+    p1.x <<= XY_SHIFT;
+    p1.y <<= XY_SHIFT;
+
+    const double ddx = static_cast<double>(p0.x - p1.x) / static_cast<double>(XY_ONE);
+    const double ddy = static_cast<double>(p1.y - p0.y) / static_cast<double>(XY_ONE);
+    double r = ddx * ddx + ddy * ddy;
+    const int odd_thickness = thickness & 1;
+    const long long th = static_cast<long long>(thickness) << (XY_SHIFT - 1);
+
+    if (std::fabs(r) > DBL_EPSILON) {
+        r = (th + odd_thickness * XY_ONE * 0.5) / std::sqrt(r);
+        const long long dpx = cvRound(ddy * r), dpy = cvRound(ddx * r);
+        const P2L quad[4] = {{p0.x + dpx, p0.y + dpy},
+                             {p0.x - dpx, p0.y - dpy},
+                             {p1.x - dpx, p1.y - dpy},
+                             {p1.x + dpx, p1.y + dpy}};
+        fill_convex_poly(quad, 4, w, h, out);
+    }
+
+    const int radius = static_cast<int>((th + (XY_ONE >> 1)) >> XY_SHIFT);
+    P2L cur = p0;
+    for (int i = 0; i < 2; i++) {
+        if (caps & (i + 1))
+            filled_disc(static_cast<int>((cur.x + (XY_ONE >> 1)) >> XY_SHIFT),
+                        static_cast<int>((cur.y + (XY_ONE >> 1)) >> XY_SHIFT), radius, w, h, out);
+        cur = p1;
+    }
+}
+
+} // namespace renderer_gpu
+
+#endif // ENABLE_GVAWATERMARK_GPU

--- a/src/monolithic/gst/elements/gvawatermark/renderer/render_prim.h
+++ b/src/monolithic/gst/elements/gvawatermark/renderer/render_prim.h
@@ -8,8 +8,11 @@
 
 #include <string>
 #include <variant>
+#include <vector>
 
 #include <opencv2/opencv.hpp>
+
+class ColorConverter;
 
 namespace render {
 
@@ -123,5 +126,10 @@ inline cv::Size computeBlurKernelSize(int roi_width, int roi_height) {
 }
 
 using Prim = std::variant<Text, Rect, Circle, Line, Polygon, InstanceSegmantationMask, SemanticSegmantationMask, Blur>;
+
+// Replaces every primitive colour with its representation in the frame's native
+// colour space, so the rasterizer only ever writes bytes. Blur and
+// SemanticSegmantationMask carry no colour and are left alone.
+void convert_prims_color(std::vector<Prim> &prims, ColorConverter &converter);
 
 } // namespace render

--- a/src/monolithic/gst/elements/gvawatermark/renderer/renderer.cpp
+++ b/src/monolithic/gst/elements/gvawatermark/renderer/renderer.cpp
@@ -44,34 +44,38 @@ std::vector<cv::Mat> Renderer::convertBufferToCvMats(dlstreamer::Frame &buffer) 
     return image_planes;
 }
 
-void Renderer::convert_prims_color(std::vector<render::Prim> &prims) {
+void render::convert_prims_color(std::vector<render::Prim> &prims, ColorConverter &converter) {
     for (auto &p : prims) {
         if (std::holds_alternative<render::Line>(p)) {
             render::Line line = std::get<render::Line>(p);
-            line.color = _color_converter->convert(line.color);
+            line.color = converter.convert(line.color);
             p = line;
         } else if (std::holds_alternative<render::Rect>(p)) {
             render::Rect rect = std::get<render::Rect>(p);
-            rect.color = _color_converter->convert(rect.color);
+            rect.color = converter.convert(rect.color);
             p = rect;
         } else if (std::holds_alternative<render::Text>(p)) {
             render::Text text = std::get<render::Text>(p);
-            text.color = _color_converter->convert(text.color);
+            text.color = converter.convert(text.color);
             p = text;
         } else if (std::holds_alternative<render::Circle>(p)) {
             render::Circle circle = std::get<render::Circle>(p);
-            circle.color = _color_converter->convert(circle.color);
+            circle.color = converter.convert(circle.color);
             p = circle;
         } else if (std::holds_alternative<render::Polygon>(p)) {
             render::Polygon polygon = std::get<render::Polygon>(p);
-            polygon.color = _color_converter->convert(polygon.color);
+            polygon.color = converter.convert(polygon.color);
             p = polygon;
         } else if (std::holds_alternative<render::InstanceSegmantationMask>(p)) {
             render::InstanceSegmantationMask mask = std::get<render::InstanceSegmantationMask>(p);
-            mask.color = _color_converter->convert(mask.color);
+            mask.color = converter.convert(mask.color);
             p = mask;
         }
     }
+}
+
+void Renderer::convert_prims_color(std::vector<render::Prim> &prims) {
+    render::convert_prims_color(prims, *_color_converter);
 }
 
 void Renderer::draw(dlstreamer::FramePtr buffer, std::vector<render::Prim> prims) {


### PR DESCRIPTION
### Description

A typical inference pipeline — decode → gvadetect → gvaclassify → fakesink — runs at over 1000 fps on my hardware. Simply inserting gvawatermark drops it to the low 300s. That is not an acceptable cost for drawing a couple of bounding boxes and labels.
Without watermark:  1039fps
With watermark(device=CPU): 330.4fps
With watermark(device=GPU): 392fps

The old "GPU" path did not actually draw on the GPU. Per frame it did:
- convertFromVASurface() — full-frame NV12 → cv::UMat BGR
- OpenCV drawing into a full-frame BGR overlay on the CPU (OpenCV's rectangle/putText/circle have no OpenCL implementation)
- full-frame host→device upload of that overlay
- cvtColor + threshold + copyTo(mask) — three full-frame OpenCL passes
- convertToVASurface() — full-frame BGR → NV12 back

**What this PR does**
The new device=GPU path renders primitives directly into the frame's Y and UV planes, so the cost is proportional to the pixels actually covered.

Per frame:

- **Import** — the VA surface's two planes are imported as cl_image objects via cl_intel_va_api_media_sharing, zero-copy. Imports are cached per VASurfaceID and released on caps change and teardown.
- **Host-side preparation** — primitive colours are converted to the frame's native YUV, so kernels only write bytes; text is rasterized with putText into a small bitmap and packed into an atlas that is uploaded once per frame (with a cross-frame cache, since labels rarely change).
- **Dispatch** — OpenCL kernels write the planes directly: rects, lines, circles, atlas/mask blits, and a separable two-pass Gaussian for blur, which now runs on the GPU as well and covers both planes.

Two details worth calling out:

- Draw order. Work items within one NDRange are unordered, so overlapping primitives of different colours would race. Shapes are rasterized host-side into per-row spans where a new run clips the ones beneath it, and the remaining primitives are split into separate dispatches wherever one overlaps a differently-coloured predecessor. The in-order queue then reproduces CPU painter semantics.
- Bit-exactness. Matching the CPU renderer required following RendererNV12 exactly — halved chroma thickness and coordinates, the br() - (1,1) corner convention, the Y-plane parity double-draw, and OpenCV's sepFilter2D rounding in the blur.
- This also fixes a latent bug in the old path, where threshold(gray, 0, 255, THRESH_BINARY) made pure black primitives invisible.

All new code is behind ENABLE_GVAWATERMARK_GPU; builds without OpenCL are unchanged.


### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

